### PR TITLE
Add: "auto-label" GitHub Workflow for Automated Labeling 

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,36 @@
+name: Auto Label Issue
+
+on:
+  issues:
+    types: [opened, reopened, edited]
+
+jobs:
+  label_issue:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Label Issue
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const issue = context.payload.issue;
+            const issueBody = issue.body ? issue.body.toLowerCase() : '';
+            const issueTitle = issue.title.toLowerCase();
+            
+            // Add gssoc label to all issues
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: ['gssoc-ext','hacktoberfest-accepted','hacktoberfest']
+            });
+            const addLabel = async (label) => {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: [label]
+              });
+            };


### PR DESCRIPTION
fixed #76 
**Objective:** Implement an "auto-label" GitHub workflow to automatically assign the "gssoc-ext" and "hacktoberfest-accepted" labels to relevant pull requests and issues.

**Details:**

- This workflow will streamline the labeling process by automatically applying the "gssoc-ext" and the "hacktoberfest-accepted" label to Issues.
- By automating these labels, we can ensure consistent tracking and visibility of contributions tied to these significant events.


Implementing this "auto-label" workflow will enhance project organization 

