### PR TITLE
fixing the "Delete Button" in the review section

### DIFF
--- a/views/show.ejs
+++ b/views/show.ejs
@@ -85,6 +85,11 @@
     }
 }
 
+/* delete btn */
+#delted_btn{
+    border: none;
+    background-color: transparent;
+}
 </style>
 
 <body class="mt-10">
@@ -219,7 +224,7 @@
                                         <div>
                                             <% if (currUser && currUser._id.equals(review.author._id)) { %>
                                                 <form method="post" action="/listing/<%= list._id %>/review/<%= review._id %>?_method=DELETE" class="text-center">
-                                                    <i class="fa-solid trash fa-trash-can"></i>
+                                                    <button type="submit" id="delted_btn"><i class="fa-solid trash fa-trash-can"></i></button>
                                                 </form>
                                             <% } %>
                                         </div>


### PR DESCRIPTION
Fixes #104

Fixes the issue where the "Delete" button in the review section.
Ensures that clicking the button triggers the deletion of the review from both the database and the UI.

### Changes
- Corrected the DELETE route handling in the backend from the database.
- Updated the frontend logic to handle the form submission for review deletion.
- Added success & error handling for better feedback to the user.


### Screenshots (if applicable):

https://github.com/user-attachments/assets/3f312080-ce61-48bc-bab6-0dec645f5570




### Checklist
- [ ]  I have tested the functionality of the "Delete" button for reviews.
- [ ]  I have verified that the DELETE route is working as expected.
- [ ]  I have performed a self-review of my code.
- [ ]  No new warnings were introduced.