### PR TITLE
adding dark mode on the /terms page (#136)

### DIFF
--- a/views/terms.ejs
+++ b/views/terms.ejs
@@ -41,6 +41,24 @@
         text-align: center;
         font-size: 32px;
     }
+
+     /* DARKMODE CSS */
+     .dark-mode {
+        h3{
+            color: #dfdfdf;
+        }
+        b {
+            color: #f7f7f7;
+        } 
+        p , li {
+            color: #dfdfdf;
+        }
+   
+        .content-wrapper {
+            background-color: transparent;
+        }
+
+    } 
 </style>
 <body>
     <h3 style="text-align: center;">Terms and Conditions</h3>


### PR DESCRIPTION
Fixes #136

This PR implements dark mode support for the /terms page. When dark mode is activated, the page now properly reflects a dark theme, ensuring improved readability and consistency with the overall site design.