### PR TITLE
 implementing dark mode on the sign-up page ((#139)

### DIFF
--- a/views/login.ejs
+++ b/views/login.ejs
@@ -1,58 +1,11 @@
 <% layout("/layouts/boilerplate") %>
 <br>
 <br>
-<style>
-/* Form Container - Floating Effect */
-.dark-mode{
-    .form_body {
-        background-color: #1e1e1e;
-        border-radius: 10px;
-        padding: 30px;
-        box-shadow: 0 7px 15px rgba(0, 0, 0, 0.5); /* Initial shadow to lift form */
-        transition: transform 0.3s ease, box-shadow 0.3s ease; /* Smooth hover transition */
-    }
-
-    .form_body:hover {
-        transform: translateY(-5px); /* Moves the form upward */
-        box-shadow: 0 10px 20px rgba(0, 0, 0, 0.8); /* Increases shadow to create more depth */
-    }
-
-    /* Input Fields Styling */
-    .login_form input[type="text"], input[type="password"] {
-        background-color: #2c2c2c;
-        color: #ffffff;
-        border: 1px solid #555555;
-        transition: box-shadow 0.3s ease; /* Smooth hover transition for input */
-    }
-
-    .login_form input[type="text"]::placeholder,
-    .login_form input[type="password"]::placeholder {
-        color: #aaaaaa;
-        border: 1px solid #555555;
-        border-radius: 5px;
-        padding: 12px;
-        width: 100%;
-        margin-top: 10px;
-    }
-
-    .login_form button[type="submit"] {
-        border: 2px solid #999;
-        color: #999;
-    }
-    .login_form button[type="submit"]:hover {
-        color: #333;
-        border: none;
-        background: #999;
-    }
-
-
-}
-</style>
 
 <div class="row">
-    <div class="col-6 offset-3 form_body">
+    <div class="col-6 offset-3">
         <form method="POST" action="/login" novalidate class="needs-validation">
-            <div class="mb-3 login_form">
+            <div class="mb-3">
                 <label for="username" class="form-label">Username</label>
                 <br>
                 <input type="text" name="username" placeholder="Username" class="form-control" required>
@@ -61,7 +14,7 @@
                     Username not found
                </div>
             </div>
-            <div class="mb-3 login_form">
+            <div class="mb-3">
                 <label for="password" class="form-label">Password</label>
                 <br>
                 <input type="password" name="password" placeholder="Password"  class="form-control" required>
@@ -71,7 +24,7 @@
               </div>
               <br>
               
-                <button class="btn col-6 offset-3" name="saveButton" type="submit">LOGIN</button>
+                <button class="btn offset-6" name="saveButton" type="submit">LOGIN</button>
             </div>
         </form>
         

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -1,11 +1,58 @@
 <% layout("/layouts/boilerplate") %>
 <br>
 <br>
+<style>
+/* Form Container - Floating Effect */
+.dark-mode{
+    .form_body {
+        background-color: #1e1e1e;
+        border-radius: 10px;
+        padding: 30px;
+        box-shadow: 0 7px 15px rgba(0, 0, 0, 0.5); /* Initial shadow to lift form */
+        transition: transform 0.3s ease, box-shadow 0.3s ease; /* Smooth hover transition */
+    }
+
+    .form_body:hover {
+        transform: translateY(-5px); /* Moves the form upward */
+        box-shadow: 0 10px 20px rgba(0, 0, 0, 0.8); /* Increases shadow to create more depth */
+    }
+
+    /* Input Fields Styling */
+    .login_form input[type="text"], input[type="password"] {
+        background-color: #2c2c2c;
+        color: #ffffff;
+        border: 1px solid #555555;
+        transition: box-shadow 0.3s ease; /* Smooth hover transition for input */
+    }
+
+    .login_form input[type="text"]::placeholder,
+    .login_form input[type="password"]::placeholder {
+        color: #aaaaaa;
+        border: 1px solid #555555;
+        border-radius: 5px;
+        padding: 12px;
+        width: 100%;
+        margin-top: 10px;
+    }
+
+    .login_form button[type="submit"] {
+        border: 2px solid #999;
+        color: #999;
+    }
+    .login_form button[type="submit"]:hover {
+        color: #333;
+        border: none;
+        background: #999;
+    }
+
+
+}
+</style>
 
 <div class="row">
-    <div class="col-6 offset-3">
+    <div class="col-6 offset-3 form_body">
         <form method="POST" action="/login" novalidate class="needs-validation">
-            <div class="mb-3">
+            <div class="mb-3 login_form">
                 <label for="username" class="form-label">Username</label>
                 <br>
                 <input type="text" name="username" placeholder="Username" class="form-control" required>
@@ -14,7 +61,7 @@
                     Username not found
                </div>
             </div>
-            <div class="mb-3">
+            <div class="mb-3 login_form">
                 <label for="password" class="form-label">Password</label>
                 <br>
                 <input type="password" name="password" placeholder="Password"  class="form-control" required>
@@ -24,7 +71,7 @@
               </div>
               <br>
               
-                <button class="btn offset-6" name="saveButton" type="submit">LOGIN</button>
+                <button class="btn col-6 offset-3" name="saveButton" type="submit">LOGIN</button>
             </div>
         </form>
         

--- a/views/signup.ejs
+++ b/views/signup.ejs
@@ -1,10 +1,59 @@
 <% layout("/layouts/boilerplate") %>
 <br>
 <br>
+<style>
+    /* Form Container - Floating Effect */
+    .dark-mode{
+        .form_body {
+            background-color: #1e1e1e;
+            border-radius: 10px;
+            padding: 30px;
+            box-shadow: 0 7px 15px rgba(0, 0, 0, 0.5);
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+        }
+    
+        .form_body:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 10px 20px rgba(0, 0, 0, 0.8);
+        }
+        .form-label {
+            color: #ffffff;
+        }
+        /* Input Fields Styling */
+        .signup_form input[type="text"], input[type="password"] {
+            background-color: #2c2c2c;
+            color: #ffffff;
+            border: 1px solid #555555;
+            transition: box-shadow 0.3s ease;
+        }
+    
+        .signup_form input[type="text"]::placeholder,
+        .signup_form input[type="password"]::placeholder {
+            color: #aaaaaa;
+            border: 1px solid #555555;
+            border-radius: 5px;
+            padding: 12px;
+            width: 100%;
+            margin-top: 10px;
+        }
+    
+        .signup_form button[type="submit"] {
+            border: 2px solid #999;
+            color: #999;
+        }
+        .signup_form button[type="submit"]:hover {
+            color: #333;
+            border: none;
+            background: #999;
+        }
+    
+    
+    }
+    </style>
 <div class="row">
-    <div class="col-6 offset-3">
+    <div class="col-6 offset-3 form_body">
         <form method="POST" action="/signup" novalidate class="needs-validation">
-            <div class="mb-3">
+            <div class="mb-3 signup_form">
                 <label for="username" class="form-label">Username</label>
                 <br>
                 <input type="text" name="username" placeholder="Username" class="form-control" required>
@@ -14,7 +63,9 @@
                 <div class="invalid-feedback">
                     Please enter valid username
                </div>
-               <label for="email" class="form-label">Email Id</label>
+            </div>
+            <div class="mb-3 signup_form">
+                <label for="email" class="form-label">Email Id</label>
                 <br>
                 <input type="email" name="email" placeholder="Email"  class="form-control"required>
                 <div class="valid-feedback">
@@ -24,7 +75,7 @@
                     Please enter valid username
                </div>
             </div>
-            <div class="mb-3">
+            <div class="mb-3 signup_form">
                 <label for="password" class="form-label">Password</label>
                 <br>
                 <input type="password" name="password" placeholder="Password"  class="form-control" required>
@@ -35,7 +86,7 @@
                    Please enter valid password
               </div>
               <br>
-              <div class="mb-3">
+              <div class="mb-3 signup_form">
                 <label for="password" class="form-label">Confirm Password</label>
                 <br>
                 <input type="password" name="cnf-password" placeholder="Password"  class="form-control" required>
@@ -47,7 +98,7 @@
               </div>
               <br>
               
-                <button class="btn offset-6" name="saveButton" type="submit">Signup</button>
+                <button class="btn col-6 offset-3" name="saveButton" type="submit">Signup</button>
             </div>
         </form>
         


### PR DESCRIPTION
Fixes #139

Added dark mode support to the sign-up page with light-colored text, inputs, and buttons, improving the overall user experience
.
### Changes

- Applied dark mode styles to the sign-up page, including:
- Dark background for the page.
- Light-colored text for form labels and placeholders.
- Adjusted the styles of input fields, buttons, and links for better contrast in dark mode.