### PR TITLE
Changes for updating map pointer in edit route ISSUE #81

### DIFF
--- a/controllers/listing.js
+++ b/controllers/listing.js
@@ -170,6 +170,19 @@ module.exports.saveEditpost = async (req, res) => {
             return res.redirect(`/listing/${id}`);
         }
 
+        // Extract location
+        let location = req.body.listing.location
+
+        // Forword geocodding.using mapbox SDK
+        const geoData = await geocodingClient.forwardGeocode({
+            query: location,
+            limit: 1
+        }).send();
+
+        // Extract updated geometry
+        let updatedGeometry = geoData.body.features[0].geometry;
+
+
         let editList = await listing.findById(id);
 
         if (req.files && req.files.length > 0) {
@@ -188,8 +201,9 @@ module.exports.saveEditpost = async (req, res) => {
         editList.title = req.body.listing.title;
         editList.description = req.body.listing.description;
         editList.price = req.body.listing.price;
-        editList.location = req.body.listing.location;
+        editList.location = location; // Pass new location
         editList.country = req.body.listing.country;
+        editList.geometry = updatedGeometry; // Save the GeoJSON object in geometry
 
         await editList.save();
 


### PR DESCRIPTION
### Description
In Edit route the map pointer is not updating if user update the listing location. So I add forword geocodding with help of mapbox SDK in '/edit' route. As you can see in the attached video.

## This PR does the following:
- Add forword geocodding for '/edit' route
- With the help of mapbox SDK
- Return new listing geocodding, Destroy the previous.

### Related Issues
Link any related issues using the format Fixes #81 . 
This helps to automatically close related issues when the PR is merged.
Fixes #81 

### Changes
List the detailed changes made in this PR.

- Fixed a bug in ... Listing `/edit` route

### Testing Instructions
Detailed instructions on how to test the changes. Include any setup needed and specific test cases.
1. Pull this branch.
2. Run `npm install` to install dependencies.
3. Run `npm test` to execute the test suite.
4. Verify that ...

### Screenshots (if applicable)
Add any screenshots that help explain or visualize the changes.

https://github.com/user-attachments/assets/b37b33f6-95ce-4a90-a479-70e723915f02


### Additional Context
@Soujanya2004  Please marge this PR asap. And also don't forget to add labels under `gssoc-extd` & `label-2` as per ISSUE #81 

### Checklist
Make sure to check off all the items before submitting. Mark with [x] if done.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I am working on this issue under GSSOC
