### PR TITLE
Adding dark mode on the Show Listing page

### DIFF
--- a/views/login.ejs
+++ b/views/login.ejs
@@ -1,58 +1,11 @@
 <% layout("/layouts/boilerplate") %>
 <br>
 <br>
-<style>
-/* Form Container - Floating Effect */
-.dark-mode{
-    .form_body {
-        background-color: #1e1e1e;
-        border-radius: 10px;
-        padding: 30px;
-        box-shadow: 0 7px 15px rgba(0, 0, 0, 0.5); /* Initial shadow to lift form */
-        transition: transform 0.3s ease, box-shadow 0.3s ease; /* Smooth hover transition */
-    }
-
-    .form_body:hover {
-        transform: translateY(-5px); /* Moves the form upward */
-        box-shadow: 0 10px 20px rgba(0, 0, 0, 0.8); /* Increases shadow to create more depth */
-    }
-
-    /* Input Fields Styling */
-    .login_form input[type="text"], input[type="password"] {
-        background-color: #2c2c2c;
-        color: #ffffff;
-        border: 1px solid #555555;
-        transition: box-shadow 0.3s ease; /* Smooth hover transition for input */
-    }
-
-    .login_form input[type="text"]::placeholder,
-    .login_form input[type="password"]::placeholder {
-        color: #aaaaaa;
-        border: 1px solid #555555;
-        border-radius: 5px;
-        padding: 12px;
-        width: 100%;
-        margin-top: 10px;
-    }
-
-    .login_form button[type="submit"] {
-        border: 2px solid #999;
-        color: #999;
-    }
-    .login_form button[type="submit"]:hover {
-        color: #333;
-        border: none;
-        background: #999;
-    }
-
-
-}
-</style>
 
 <div class="row">
-    <div class="col-6 offset-3 form_body">
+    <div class="col-6 offset-3">
         <form method="POST" action="/login" novalidate class="needs-validation">
-            <div class="mb-3 login_form">
+            <div class="mb-3">
                 <label for="username" class="form-label">Username</label>
                 <br>
                 <input type="text" name="username" placeholder="Username" class="form-control" required>
@@ -61,7 +14,7 @@
                     Username not found
                </div>
             </div>
-            <div class="mb-3 login_form">
+            <div class="mb-3">
                 <label for="password" class="form-label">Password</label>
                 <br>
                 <input type="password" name="password" placeholder="Password"  class="form-control" required>
@@ -71,7 +24,7 @@
               </div>
               <br>
               
-                <button class="btn col-6 offset-3" name="saveButton" type="submit">LOGIN</button>
+                <button class="btn offset-6" name="saveButton" type="submit">LOGIN</button>
             </div>
         </form>
         

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -1,11 +1,58 @@
 <% layout("/layouts/boilerplate") %>
 <br>
 <br>
+<style>
+/* Form Container - Floating Effect */
+.dark-mode{
+    .form_body {
+        background-color: #1e1e1e;
+        border-radius: 10px;
+        padding: 30px;
+        box-shadow: 0 7px 15px rgba(0, 0, 0, 0.5); /* Initial shadow to lift form */
+        transition: transform 0.3s ease, box-shadow 0.3s ease; /* Smooth hover transition */
+    }
+
+    .form_body:hover {
+        transform: translateY(-5px); /* Moves the form upward */
+        box-shadow: 0 10px 20px rgba(0, 0, 0, 0.8); /* Increases shadow to create more depth */
+    }
+
+    /* Input Fields Styling */
+    .login_form input[type="text"], input[type="password"] {
+        background-color: #2c2c2c;
+        color: #ffffff;
+        border: 1px solid #555555;
+        transition: box-shadow 0.3s ease; /* Smooth hover transition for input */
+    }
+
+    .login_form input[type="text"]::placeholder,
+    .login_form input[type="password"]::placeholder {
+        color: #aaaaaa;
+        border: 1px solid #555555;
+        border-radius: 5px;
+        padding: 12px;
+        width: 100%;
+        margin-top: 10px;
+    }
+
+    .login_form button[type="submit"] {
+        border: 2px solid #999;
+        color: #999;
+    }
+    .login_form button[type="submit"]:hover {
+        color: #333;
+        border: none;
+        background: #999;
+    }
+
+
+}
+</style>
 
 <div class="row">
-    <div class="col-6 offset-3">
+    <div class="col-6 offset-3 form_body">
         <form method="POST" action="/login" novalidate class="needs-validation">
-            <div class="mb-3">
+            <div class="mb-3 login_form">
                 <label for="username" class="form-label">Username</label>
                 <br>
                 <input type="text" name="username" placeholder="Username" class="form-control" required>
@@ -14,7 +61,7 @@
                     Username not found
                </div>
             </div>
-            <div class="mb-3">
+            <div class="mb-3 login_form">
                 <label for="password" class="form-label">Password</label>
                 <br>
                 <input type="password" name="password" placeholder="Password"  class="form-control" required>
@@ -24,7 +71,7 @@
               </div>
               <br>
               
-                <button class="btn offset-6" name="saveButton" type="submit">LOGIN</button>
+                <button class="btn col-6 offset-3" name="saveButton" type="submit">LOGIN</button>
             </div>
         </form>
         

--- a/views/show.ejs
+++ b/views/show.ejs
@@ -100,6 +100,61 @@
         height: 200px; 
     }
 }
+
+/* Form Container - Floating Effect */
+.dark-mode{
+    /* show listing */
+    h1, h2, h3, h4, p, .card-title {
+        color: #e0e0e0;
+    }
+
+    .card {
+        border: 1px solid #333;
+        box-shadow: -1px 4px 12px rgba(3, 3, 3, 0.4);
+    }
+
+    .listing-card {
+        background-color: #282828;
+    }
+
+    .show-img {
+        border: 1px solid #333;
+    }
+
+    /* REVIEW */
+    /* Input Fields Styling */
+    .review-form input {
+        background-color: #2c2c2c;
+        color: #ffffff;
+        border: 1px solid #555555;
+        transition: box-shadow 0.3s ease; /* Smooth hover transition for input */
+    }
+
+    .review-form input[type="text"]::placeholder{
+        color: #aaaaaa;
+        border: 1px solid #555555;
+        border-radius: 5px;
+        padding: 12px;
+        width: 100%;
+        margin-top: 10px;
+    }
+
+    .review-form button[type="submit"] {
+        border: 2px solid #999;
+        color: #999;
+        background: #d4d4d4;
+    }
+    .review-form button[type="submit"]:hover {
+        color: #333;
+        border: none;
+        background: #fdfdfd;
+    }
+
+    .text-muted {
+    --bs-text-opacity: 1;
+    color:  #e0e0e0 !important;
+}
+}
 </style>
 
 <body class="mt-10">
@@ -130,7 +185,7 @@
                         </button>
                     </div>
                     <div class="card-body text-center">
-                        <h2 class="mt-5" style=" color: #022e6a; font-family: rakkas;">Owned by: <b><%= list.owner.username %></b></h2>
+                        <h2 class="mt-5" style="color: #5986c5; font-family: rakkas;">Owned by: <b><%= list.owner.username %></b></h2>
                         <b><%= list.description %></b>
                         <p class="listing-price"><b>price:</b>
                             &#8377;<%= list.price.toLocaleString("en-IN") %>/night
@@ -186,7 +241,7 @@
     
                                     <!-- Form for add reviews. -->
                                     <form action="/listing/<%= list._id %>/review" method="post" novalidate class="needs-validation">
-                                        <div>
+                                        <div class="review-form">
                                             <label for="rating" class="form-label bold2"><b>Rating:</b></label>
                                             <fieldset class="starability-grow">
                                                 


### PR DESCRIPTION
Fixes #141

Adding dark mode for the Show Listing page.

### Changes
Dark background for the page content.
Adjustments for buttons, links, and input fields to maintain contrast.

### Checklist

- [ ]  I have tested the Show Listing page in both dark and light modes.
- [ ]  The dark mode styles are consistent with the site's overall theme.
- [ ]  No new console errors or warnings were introduced during testing.
