### PR TITLE
Added dark mode on the /contributors page (#137)

### DIFF
--- a/views/contributors.ejs
+++ b/views/contributors.ejs
@@ -1,11 +1,148 @@
 <%- layout("/layouts/boilerplate") -%>
+
+<style>
+    /* Dark Theme for the Contributor Page */
+    .dark-mode {
+        .contributor-container {
+            color: #f1f1f1;
+            background-color: #1e1e1e;
+        }
+        .contributor-hero {
+            background-color: #2a2a2a;
+            color: #f1f1f1;
+        }
+        .contributor-hero p {
+            font-size: 1.5rem;
+            margin-bottom: 2rem;
+            color: #cccccc;
+        }   
+        .contributor-btn-primary {
+            background-color: #ff7f50;
+            color: #ffffff;
+            padding: 10px 20px;
+            border: none;
+            border-radius: 5px;
+            font-size: 1rem;
+            cursor: pointer;
+            transition: background-color 0.3s;
+        }
+
+        .contributor-btn-primary:hover {
+            background-color: #e06c3b;
+        }
+        .contributor-stats-grid div {
+            background-color: #2b2b2b;
+            text-align: center;
+            color: #f1f1f1;
+        }
+        
+        .contributor-stats-grid p {
+            color: #cccccc;
+        }
+        .contributor-contributor-card{
+            background-color: #2b2b2b;
+            color: #f1f1f1;
+        }
+        .contributor-contributor-card p{
+            color: #f1f1f1;
+        }
+        .contributor-contributions{
+            color: #3e3e3e;
+        }
+        .contributor-footer svg{
+            color: #646464;        
+        }
+
+        /* Dark Mode for the Footer */
+       /* Dark Theme - Contribute Section */
+        .contributor-cta {
+            background-color: #2b2b2b;
+            padding: 3rem;
+            text-align: center;
+            color: #f1f1f1;
+        }
+
+        .contributor-cta h2 {
+            font-size: 2.5rem;
+            margin-bottom: 1rem;
+            color: #ffffff;
+        }
+
+        .contributor-cta p {
+            font-size: 1.2rem;
+            margin-bottom: 2rem;
+            color: #cccccc;
+        }
+
+        /* Input Field Styling */
+        #subscribeForm {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            flex-wrap: wrap;
+        }
+
+        #emailInput {
+            padding: 10px;
+            width: 60%;
+            margin-right: 10px;
+            border: 2px solid #555555;
+            background-color: #2c2c2c;
+            color: #ffffff;
+            border-radius: 5px;
+            font-size: 1rem;
+        }
+
+        #emailInput::placeholder {
+            color: #aaaaaa;
+        }
+
+        #subscribeForm button {
+            padding: 10px 20px;
+            font-size: 1rem;
+            background-color: #ff7f50;
+            color: #ffffff;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+            transition: background-color 0.3s ease;
+        }
+
+        #subscribeForm button:hover {
+            background-color: #e06c3b;
+        }
+
+        /* Notification Styling */
+        .contributor-notification {
+            background-color: #ff7f50;
+            color: #ffffff;
+            padding: 10px;
+            border-radius: 5px;
+            margin-top: 20px;
+            display: none;
+            font-size: 1rem;
+        }
+
+        .contributor-notification.contributor-hidden {
+            display: none;
+        }
+
+        .contributor-notification.contributor-show {
+            display: block;
+        }
+
+
+    }
+</style>
+
 <div class="contributor-container">
     <!-- Hero Section -->
     <section class="contributor-hero">
         <div class="contributor-hero-content">
             <h1>Welcome to wanderlust-2024  </h1>
             <p>Empowering writers, one commit at a time</p>
-            <button class="contributor-btn contributor-btn-primary" onclick="scrollToContribute()">Become a Contributor</button>
+            <!-- <button class="contributor-btn contributor-btn-primary" onclick="scrollToContribute()">Become a Contributor</button> -->
+             <a class="btn btn-outline-danger" href="https://github.com/Soujanya2004/wanderlust-2024">Become a Contributor</a>
         </div>
     </section>
 

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -1,58 +1,11 @@
 <% layout("/layouts/boilerplate") %>
 <br>
 <br>
-<style>
-/* Form Container - Floating Effect */
-.dark-mode{
-    .form_body {
-        background-color: #1e1e1e;
-        border-radius: 10px;
-        padding: 30px;
-        box-shadow: 0 7px 15px rgba(0, 0, 0, 0.5); /* Initial shadow to lift form */
-        transition: transform 0.3s ease, box-shadow 0.3s ease; /* Smooth hover transition */
-    }
-
-    .form_body:hover {
-        transform: translateY(-5px); /* Moves the form upward */
-        box-shadow: 0 10px 20px rgba(0, 0, 0, 0.8); /* Increases shadow to create more depth */
-    }
-
-    /* Input Fields Styling */
-    .login_form input[type="text"], input[type="password"] {
-        background-color: #2c2c2c;
-        color: #ffffff;
-        border: 1px solid #555555;
-        transition: box-shadow 0.3s ease; /* Smooth hover transition for input */
-    }
-
-    .login_form input[type="text"]::placeholder,
-    .login_form input[type="password"]::placeholder {
-        color: #aaaaaa;
-        border: 1px solid #555555;
-        border-radius: 5px;
-        padding: 12px;
-        width: 100%;
-        margin-top: 10px;
-    }
-
-    .login_form button[type="submit"] {
-        border: 2px solid #999;
-        color: #999;
-    }
-    .login_form button[type="submit"]:hover {
-        color: #333;
-        border: none;
-        background: #999;
-    }
-
-
-}
-</style>
 
 <div class="row">
-    <div class="col-6 offset-3 form_body">
+    <div class="col-6 offset-3">
         <form method="POST" action="/login" novalidate class="needs-validation">
-            <div class="mb-3 login_form">
+            <div class="mb-3">
                 <label for="username" class="form-label">Username</label>
                 <br>
                 <input type="text" name="username" placeholder="Username" class="form-control" required>
@@ -61,7 +14,7 @@
                     Username not found
                </div>
             </div>
-            <div class="mb-3 login_form">
+            <div class="mb-3">
                 <label for="password" class="form-label">Password</label>
                 <br>
                 <input type="password" name="password" placeholder="Password"  class="form-control" required>
@@ -71,7 +24,7 @@
               </div>
               <br>
               
-                <button class="btn col-6 offset-3" name="saveButton" type="submit">LOGIN</button>
+                <button class="btn offset-6" name="saveButton" type="submit">LOGIN</button>
             </div>
         </form>
         

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -1,11 +1,58 @@
 <% layout("/layouts/boilerplate") %>
 <br>
 <br>
+<style>
+/* Form Container - Floating Effect */
+.dark-mode{
+    .form_body {
+        background-color: #1e1e1e;
+        border-radius: 10px;
+        padding: 30px;
+        box-shadow: 0 7px 15px rgba(0, 0, 0, 0.5); /* Initial shadow to lift form */
+        transition: transform 0.3s ease, box-shadow 0.3s ease; /* Smooth hover transition */
+    }
+
+    .form_body:hover {
+        transform: translateY(-5px); /* Moves the form upward */
+        box-shadow: 0 10px 20px rgba(0, 0, 0, 0.8); /* Increases shadow to create more depth */
+    }
+
+    /* Input Fields Styling */
+    .login_form input[type="text"], input[type="password"] {
+        background-color: #2c2c2c;
+        color: #ffffff;
+        border: 1px solid #555555;
+        transition: box-shadow 0.3s ease; /* Smooth hover transition for input */
+    }
+
+    .login_form input[type="text"]::placeholder,
+    .login_form input[type="password"]::placeholder {
+        color: #aaaaaa;
+        border: 1px solid #555555;
+        border-radius: 5px;
+        padding: 12px;
+        width: 100%;
+        margin-top: 10px;
+    }
+
+    .login_form button[type="submit"] {
+        border: 2px solid #999;
+        color: #999;
+    }
+    .login_form button[type="submit"]:hover {
+        color: #333;
+        border: none;
+        background: #999;
+    }
+
+
+}
+</style>
 
 <div class="row">
-    <div class="col-6 offset-3">
+    <div class="col-6 offset-3 form_body">
         <form method="POST" action="/login" novalidate class="needs-validation">
-            <div class="mb-3">
+            <div class="mb-3 login_form">
                 <label for="username" class="form-label">Username</label>
                 <br>
                 <input type="text" name="username" placeholder="Username" class="form-control" required>
@@ -14,7 +61,7 @@
                     Username not found
                </div>
             </div>
-            <div class="mb-3">
+            <div class="mb-3 login_form">
                 <label for="password" class="form-label">Password</label>
                 <br>
                 <input type="password" name="password" placeholder="Password"  class="form-control" required>
@@ -24,7 +71,7 @@
               </div>
               <br>
               
-                <button class="btn offset-6" name="saveButton" type="submit">LOGIN</button>
+                <button class="btn col-6 offset-3" name="saveButton" type="submit">LOGIN</button>
             </div>
         </form>
         


### PR DESCRIPTION
Fixes #137 
Adds dark mode functionality to the /contributors page. 

### Changes
- Dark background for the page.
- Light text for contributor names, descriptions, and other content.
- Ensured proper color contrast for buttons, links, and any other interactive elements.
- Maintained consistency with the rest of the site’s dark mode styling.

![Uploading localhost_8000_contributors (2).png…]()

### Checklist
- [ ]  Dark mode styles applied to all components on the /contributors page.
- [ ]  Tested across different screen sizes and devices.
- [ ]  No errors or warnings during testing in dark mode.