### PR TITLE
Toggle bug

### DIFF
--- a/public/js/toggler.js
+++ b/public/js/toggler.js
@@ -1,21 +1,40 @@
 document.addEventListener('DOMContentLoaded', () => {
-    const toggleButton = document.getElementById('darkModeToggle');
-    const toggleIcon = document.getElementById('toggleIcon');
-    const body = document.body;
-  
-    // Set the default mode based on the body's class
-    if (body.classList.contains('dark-mode')) {
+  const toggleButton = document.getElementById('darkModeToggle');
+  const toggleIcon = document.getElementById('toggleIcon');
+  const body = document.body;
+
+  // Check localStorage for theme preference
+  const isDarkMode = localStorage.getItem('darkMode') === 'true';
+
+  // Set the default mode based on localStorage
+  if (isDarkMode) {
+      body.classList.add('dark-mode');
+      body.classList.remove('light-mode');
       toggleIcon.classList.add('fa-sun');
       toggleIcon.classList.remove('fa-moon');
-    } else {
+  } else {
+      body.classList.add('light-mode');
+      body.classList.remove('dark-mode');
       toggleIcon.classList.add('fa-moon');
       toggleIcon.classList.remove('fa-sun');
-      body.classList.add('light-mode');
-    }
-  
-    toggleButton.addEventListener('click', () => {
-      body.classList.toggle('dark-mode');
-     body.classList.toggle('light-mode');
-    });
+  }
+
+  // Toggle dark mode on button click
+  toggleButton.addEventListener('click', () => {
+      const isDarkModeNow = body.classList.toggle('dark-mode');
+      body.classList.toggle('light-mode', !isDarkModeNow); // Ensure one mode is active at a time
+
+      // Save the current mode to localStorage
+      localStorage.setItem('darkMode', isDarkModeNow);
+
+      // Update the icon based on the current mode
+      if (isDarkModeNow) {
+          toggleIcon.classList.add('fa-sun');
+          toggleIcon.classList.remove('fa-moon');
+      } else {
+          toggleIcon.classList.add('fa-moon');
+          toggleIcon.classList.remove('fa-sun');
+      }
   });
-  
+});
+``

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -1,58 +1,11 @@
 <% layout("/layouts/boilerplate") %>
 <br>
 <br>
-<style>
-/* Form Container - Floating Effect */
-.dark-mode{
-    .form_body {
-        background-color: #1e1e1e;
-        border-radius: 10px;
-        padding: 30px;
-        box-shadow: 0 7px 15px rgba(0, 0, 0, 0.5); /* Initial shadow to lift form */
-        transition: transform 0.3s ease, box-shadow 0.3s ease; /* Smooth hover transition */
-    }
-
-    .form_body:hover {
-        transform: translateY(-5px); /* Moves the form upward */
-        box-shadow: 0 10px 20px rgba(0, 0, 0, 0.8); /* Increases shadow to create more depth */
-    }
-
-    /* Input Fields Styling */
-    .login_form input[type="text"], input[type="password"] {
-        background-color: #2c2c2c;
-        color: #ffffff;
-        border: 1px solid #555555;
-        transition: box-shadow 0.3s ease; /* Smooth hover transition for input */
-    }
-
-    .login_form input[type="text"]::placeholder,
-    .login_form input[type="password"]::placeholder {
-        color: #aaaaaa;
-        border: 1px solid #555555;
-        border-radius: 5px;
-        padding: 12px;
-        width: 100%;
-        margin-top: 10px;
-    }
-
-    .login_form button[type="submit"] {
-        border: 2px solid #999;
-        color: #999;
-    }
-    .login_form button[type="submit"]:hover {
-        color: #333;
-        border: none;
-        background: #999;
-    }
-
-
-}
-</style>
 
 <div class="row">
-    <div class="col-6 offset-3 form_body">
+    <div class="col-6 offset-3">
         <form method="POST" action="/login" novalidate class="needs-validation">
-            <div class="mb-3 login_form">
+            <div class="mb-3">
                 <label for="username" class="form-label">Username</label>
                 <br>
                 <input type="text" name="username" placeholder="Username" class="form-control" required>
@@ -61,7 +14,7 @@
                     Username not found
                </div>
             </div>
-            <div class="mb-3 login_form">
+            <div class="mb-3">
                 <label for="password" class="form-label">Password</label>
                 <br>
                 <input type="password" name="password" placeholder="Password"  class="form-control" required>
@@ -71,7 +24,7 @@
               </div>
               <br>
               
-                <button class="btn col-6 offset-3" name="saveButton" type="submit">LOGIN</button>
+                <button class="btn offset-6" name="saveButton" type="submit">LOGIN</button>
             </div>
         </form>
         

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -1,11 +1,58 @@
 <% layout("/layouts/boilerplate") %>
 <br>
 <br>
+<style>
+/* Form Container - Floating Effect */
+.dark-mode{
+    .form_body {
+        background-color: #1e1e1e;
+        border-radius: 10px;
+        padding: 30px;
+        box-shadow: 0 7px 15px rgba(0, 0, 0, 0.5); /* Initial shadow to lift form */
+        transition: transform 0.3s ease, box-shadow 0.3s ease; /* Smooth hover transition */
+    }
+
+    .form_body:hover {
+        transform: translateY(-5px); /* Moves the form upward */
+        box-shadow: 0 10px 20px rgba(0, 0, 0, 0.8); /* Increases shadow to create more depth */
+    }
+
+    /* Input Fields Styling */
+    .login_form input[type="text"], input[type="password"] {
+        background-color: #2c2c2c;
+        color: #ffffff;
+        border: 1px solid #555555;
+        transition: box-shadow 0.3s ease; /* Smooth hover transition for input */
+    }
+
+    .login_form input[type="text"]::placeholder,
+    .login_form input[type="password"]::placeholder {
+        color: #aaaaaa;
+        border: 1px solid #555555;
+        border-radius: 5px;
+        padding: 12px;
+        width: 100%;
+        margin-top: 10px;
+    }
+
+    .login_form button[type="submit"] {
+        border: 2px solid #999;
+        color: #999;
+    }
+    .login_form button[type="submit"]:hover {
+        color: #333;
+        border: none;
+        background: #999;
+    }
+
+
+}
+</style>
 
 <div class="row">
-    <div class="col-6 offset-3">
+    <div class="col-6 offset-3 form_body">
         <form method="POST" action="/login" novalidate class="needs-validation">
-            <div class="mb-3">
+            <div class="mb-3 login_form">
                 <label for="username" class="form-label">Username</label>
                 <br>
                 <input type="text" name="username" placeholder="Username" class="form-control" required>
@@ -14,7 +61,7 @@
                     Username not found
                </div>
             </div>
-            <div class="mb-3">
+            <div class="mb-3 login_form">
                 <label for="password" class="form-label">Password</label>
                 <br>
                 <input type="password" name="password" placeholder="Password"  class="form-control" required>
@@ -24,7 +71,7 @@
               </div>
               <br>
               
-                <button class="btn offset-6" name="saveButton" type="submit">LOGIN</button>
+                <button class="btn col-6 offset-3" name="saveButton" type="submit">LOGIN</button>
             </div>
         </form>
         


### PR DESCRIPTION
Fixes #149

Resolves the issue where the dark mode preference resets when navigating between pages. It ensures that the dark mode setting is saved and consistently applied across all pages, improving user experience.

### Changes
- Implemented **localStorage** to save the user's dark mode preference.
- On each page load, the script checks localStorage for the stored theme (dark or light) and applies it accordingly.
- Updated the dark mode toggle button to reflect the current theme (whether stored or default).

### Screenshots (if applicable)

Uploading 20.10.2024_21.25.05_REC.mp4…


### Expected Behavior
Dark mode preference should persist across all pages and after refreshing the browserased on the following...

### Checklist

- [ ]  Tested the dark mode toggle functionality.
- [ ]  Confirmed that the dark mode preference persists across different pages.
- [ ]  Verified the functionality on both desktop and mobile views.
- [ ]  I am working on this issue under GSSOC
