### PR TITLE
Added dark mode for the "Page Not Found" page (#181)

### DIFF
--- a/views/not_found.ejs
+++ b/views/not_found.ejs
@@ -19,6 +19,27 @@
     .not-found-content h1{
         font-family: rakkas;
     }
+
+    .dark-mode{
+        .not-found {
+            /* background-color: #1a1a1a; */
+            color: #f1f1f1;
+        }
+
+        .not-found-content h1 {
+            color: #ff385c;
+        }
+
+         .not-found-content p {
+            color: #f1f1f1;
+        }
+
+
+         .not-found-image {
+            filter: brightness(80%);
+        }
+
+    } 
 </style>
 
 


### PR DESCRIPTION
Fixes #181

This PR fixes the issue where the "Page Not Found" page (404) does not display correctly in dark mode. The text was not visible, leading to poor user experience when dark mode is enabled.

### Changes
Adjusted the CSS for the "Page Not Found" page to apply proper color adjustments for dark mode.
Text now changes to a lighter color on a dark background.
Buttons, links, and other UI elements have been updated for better visibility in dark mode.


### Screenshots (if applicable)
current

updated:
![Uploading Screenshot (214).png…]()

### Checklist

- [ ]  Tested dark mode on the "Page Not Found" page.
- [ ]  Verified the fix on both desktop and mobile views.
- [ ]  Ensured text and elements are properly visible in dark mode.