### PR TITLE
Change in price field. Make it type number only

### DIFF
--- a/views/new.ejs
+++ b/views/new.ejs
@@ -92,7 +92,7 @@
                     <div class="mb-3 col-3 listing_form">
                         <label for="price" class="form-label">Price</label>
                         <br>
-                        <input name="listing[price]" class="form-control" placeholder="Enter price" required>
+                        <input name="listing[price]" class="form-control" type="number" placeholder="Enter price" required>
                         <div class="invalid-feedback">Please add a price!</div>
                         <div class="valid-feedback">Looks good!</div>
                     </div>


### PR DESCRIPTION
### Description
I fix the price input field type to number. Now it only take input number. 
- This PR does the following:
  - Updates ... The price input field

### Related Issues
Link any related issues using the format `Fixes #issue_number`. 
This helps to automatically close related issues when the PR is merged.
- Placeholder: "Fixes #193 "


### Screenshots (if applicable)
Add any screenshots that help explain or visualize the changes.


### Additional Context
Any additional context or information that reviewers should be aware of.
- This PR is based on the following...
![image](https://github.com/user-attachments/assets/a61f1af1-92da-4a81-ae5b-475f0151582f)

### Checklist
Make sure to check off all the items before submitting. Mark with [x] if done.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I am working on this issue under GSSOC
### @Soujanya2004  Please marge it. And don't forget to add all the labels as per the ISSUE #193 