### PR TITLE
Add Toggle Button for Total Price Including GST on Listings Page (Fixes #241)

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -13,8 +13,25 @@
     position: absolute;
     bottom: 1.2rem !important;
   }
-
-
+  /* Styling for GST toggle */
+        .tax-toggler-container {
+            display: flex;
+            justify-content: flex-end;
+          }
+        .tax-toggler {
+          box-shadow: 1px 2px 8px rgba(0, 0, 0, 0.2); 
+          width: 200px;
+          position: relative;
+          right: 1rem; 
+          padding: 8px 14px;
+          border-radius: 8px;
+          z-index: 10;
+            }
+        .tax-toggler label {
+            font-size: 11px;
+            margin-left: 5px;
+            cursor: pointer;
+        }
 </style>
 <body>
   
@@ -74,7 +91,17 @@
     <!-- LISTINGS -->
   <br>
   <!-- Listings -->
-  <div class="container my-4">
+  <div class="container">
+    <!-- toogler -->
+    <div class="tax-toggler-container">
+      <div class="tax-toggler">
+        <div class="form-check-reverse form-switch">
+          <input type="checkbox" role="switch" class="form-check-input" id="gstToggle" onclick="toggleGST()">
+          <label for="gstToggle" class="form-check-label">Display total after taxes</label>
+        </div>
+      </div>
+    </div>
+  </div>
     <div class="row">
       <% for( listing of listings) { %>
         <div class="col-lg-4 col-md-6">
@@ -84,13 +111,16 @@
               <h5 class="card-title"><%= listing.title %></h5>
 
                 <% if (listing.description.length < 100) { %>
-                  <p class="card-text"><i><%= listing.description %></i>              
+                  <p class="card-text"><i><%= listing.description %></i></p>            
                 <% } else if (listing.description.length > 100) {%>
-                  <p class="card-text desc"><i><%= listing.description.slice(0,70) %></i>              
-                <a class="btn btn-link" href="/listing/<%= listing._id %>">Show More</a>
+                  <p class="card-text desc"><i><%= listing.description.slice(0, 70) %></i>
+                  <a class="btn btn-link" href="/listing/<%= listing._id %>">Show More</a></p>
               <% } %> 
 
-              <br>&#8377;<%= listing.price.toLocaleString("en-IN") %> / night</p>
+              <p class="card-text">
+                &#8377;<span class="price" data-base-price="<%= listing.price %>"><%= listing.price.toLocaleString("en-IN") %></span> / night 
+                <span class="gst-label">(excl. GST)</span>
+              </p>              
               <p class="card-text">Location: <%= listing.location %>, <%= listing.country %></p>
               <a href="/listing/<%= listing._id %>" class="btn btn-dark show_btn">Show in Detail</a>
             </div>
@@ -153,7 +183,38 @@
   </div>
 </div>
 
+<!-- GST CALCULATE -->
+<script>
+  //Change the gstRate accordingly
+const gstRate = 0.18;
 
+function toggleGST() {
+  const gstToggle = document.getElementById("gstToggle");
+  const priceElements = document.querySelectorAll(".price");
+  const gstLabels = document.querySelectorAll(".gst-label");
+
+  priceElements.forEach((priceElement, index) => {
+    const basePrice = parseFloat(priceElement.getAttribute("data-base-price"));
+    const totalPrice = basePrice * (1 + gstRate);
+
+    if (gstToggle.checked) {
+      // Show GST
+      priceElement.innerText = totalPrice.toLocaleString("en-IN", { style: "currency", currency: "INR" });
+      gstLabels[index].innerText = "(incl. GST)";
+    } else {
+      // without GST
+      priceElement.innerText = basePrice.toLocaleString("en-IN", { style: "currency", currency: "INR" });
+      gstLabels[index].innerText = "(excl. GST)";
+    }
+  });
+}
+
+// Initialize with base prices
+document.addEventListener("DOMContentLoaded", toggleGST);
+</script>
+
+
+<!-- FILLTERS -->
 <script>
   const filters = document.getElementById('filters');
   const leftButton = document.querySelector('.left');
@@ -177,6 +238,8 @@ leftButton.addEventListener('click',scrollLeft);
 rightButton.addEventListener('click',scrollRight);
 
 </script>
+
+<!-- FILLTERS -->
 <script>
   document.querySelectorAll('.faq-item').forEach(item => {
     item.addEventListener('click', () => {
@@ -202,6 +265,9 @@ rightButton.addEventListener('click',scrollRight);
     });
 });
 </script>
+
+
+<!-- FILLTERS -->
 <script>
   document.addEventListener("DOMContentLoaded", function () {
     const toggleDescriptionLinks = document.querySelectorAll('.toggle-description');


### PR DESCRIPTION
Fixes #241

Added a toggle button on the listing page, allowing users to view the total price with GST included. This feature aligns with platforms like Airbnb, enhancing pricing transparency and improving user trust


### Changes
1. Added Toggle Button: A new toggle switch labeled "Display total with GST" is added next to the filter options on the listings page for easy visibility.
2. GST Calculation: Integrated functionality to dynamically include GST in the displayed price when the toggle is enabled, providing users with the full cost view.


### Screenshots (if applicable)

https://github.com/user-attachments/assets/f8e13ccc-f3fc-48a6-a7d9-157f20540baa

### Checklist
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I am working on this issue under GSSOC
