### PR TITLE
Change position of the flash msg

### DIFF
--- a/views/includes/flash.ejs
+++ b/views/includes/flash.ejs
@@ -2,7 +2,7 @@
 <% if(success && success.length){ %>
 
     <button type="button" class="btn btn-primary" id="liveToastBtn" style="display:none;">Show live toast</button>
-    <div class="toast-container position-fixed bottom-0 end-0 p-3">
+    <div class="toast-container position-fixed top-4 end-0 p-5">
         <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">
             <div class="toast-header bg-success bg-gradient text-white">
                 <strong class="me-auto">Success</strong>
@@ -22,7 +22,7 @@
 <% if(error && error.length){ %>
 
     <button type="button" class="btn btn-primary" id="liveToastBtn" style="display:none;">Show live toast</button>
-    <div class="toast-container position-fixed bottom-0 end-0 p-3">
+    <div class="toast-container position-fixed top-4 end-0 p-5">
         <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">
             <div class="toast-header bg-danger bg-gradient text-white">
                 <strong class="me-auto">Error</strong>


### PR DESCRIPTION
### Description
As you can seen in the screenshot. I change the position of the flash message. I placed it in top end corner with some top margin. Which looks good also solve the over lapping issue.
- This PR does the following:
  - Updates ... The position of the flash message.

### Related Issues
Link any related issues using the format `Fixes #issue_number`. 
This helps to automatically close related issues when the PR is merged.
- Placeholder: "Fixes #245 "


### Screenshots (if applicable)
Add any screenshots that help explain or visualize the changes.
![image](https://github.com/user-attachments/assets/e6e7ff9c-8bdd-4149-96d3-341edfd58888)
![image](https://github.com/user-attachments/assets/ee63218e-28b0-43aa-8eca-c26006d8b144)


### Checklist
Make sure to check off all the items before submitting. Mark with [x] if done.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I am working on this issue under GSSOC
### @Soujanya2004  Marge it. And don't forget to add all the labels as per ISSUE #245 