### PR TITLE
Add default '/ ' route

### DIFF
--- a/app.js
+++ b/app.js
@@ -111,6 +111,14 @@ app.use((req, res, next) => {
   next();
 });
 
+// Default route for '/' path
+app.get("/", asyncwrap(async (req,res) => {
+
+    const listings = await listing.find();
+    res.render("index.ejs", { listings });
+  
+})); 
+
 //About us page
 app.get('/about',asyncwrap ( async (req, res) => {
   try {

--- a/views/includes/navbar.ejs
+++ b/views/includes/navbar.ejs
@@ -2,7 +2,7 @@
 <nav class="navbar navbar-expand-lg sticky-top">
   <div class="container">
     <!-- Brand and explore link on the left -->
-    <a class="navbar-brand" href="/listing"><i class="fa-solid fa-plane fa-rotate-by fa-2xl"
+    <a class="navbar-brand" href="/"><i class="fa-solid fa-plane fa-rotate-by fa-2xl"
         style="--fa-rotate-angle: -39deg;"></i></a>
     <a class="nav-link" id="explore" href="/listing">Explore</a>
 


### PR DESCRIPTION
### Description
Add the default '/ ' route as you seen in the screenshot. And also add his route into the plane icon.
Now when someone open your this `https://wanderlust-2024-tkqf.onrender.com/` hosted link directly, it doesn't show `Page NOT found` error. 

- This PR does the following:
  - Adds ... New default path


### Related Issues
Link any related issues using the format `Fixes #issue_number`. 
This helps to automatically close related issues when the PR is merged.
- Placeholder: "Fixes #252 "



### Screenshots (if applicable)
Add any screenshots that help explain or visualize the changes.
![image](https://github.com/user-attachments/assets/24821337-5693-4521-b37b-dfc143837b70)


### Checklist
Make sure to check off all the items before submitting. Mark with [x] if done.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I am working on this issue under GSSOC
### @Soujanya2004  please marge it, And don't forget to add all the labels as per ISSUE #252 