### PR TITLE
Passwords synchronization in sign up page 

### DIFF
--- a/app.js
+++ b/app.js
@@ -159,11 +159,16 @@ app.get("/signup", asyncwrap(async (req, res) => {
 }));
 
 app.post('/signup', asyncwrap(async (req, res, next) => {
-  const { username, email, password } = req.body;
+  const { username, email, password, cnfPassword } = req.body;
 
-  if (!username || !password) {
-    req.flash('error', 'Username and password are required');
+  if (!username || !password || !cnfPassword ) {
+    req.flash('error', 'All the fields are required');
     return res.redirect('/signup'); // Return to ensure single response
+  }
+
+  if(password !== cnfPassword){
+    req.flash('error', 'Both password value should be same!');
+    return res.redirect('/signup');
   }
 
   try {

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -40,6 +40,8 @@ document.addEventListener('DOMContentLoaded', function () {
       }
   }
 });
+
+// Password views eye toggler.
 document.addEventListener('DOMContentLoaded', function () {
   const togglePassword = document.querySelectorAll('.passwordToggler');
   togglePassword.forEach((toggle) => {
@@ -47,7 +49,7 @@ document.addEventListener('DOMContentLoaded', function () {
           // console.log(e.target.classList.contains('cnf-passkey'))
           let password;
           if (e.target.classList.contains('cnf-passkey'))
-              password = document.querySelector('input[name="cnf-password"]');
+              password = document.querySelector('input[name="cnfPassword"]');
           else
               password = document.querySelector('input[name="password"]');
           const type = password.getAttribute('type') === 'password' ? 'text' : 'password';
@@ -57,6 +59,8 @@ document.addEventListener('DOMContentLoaded', function () {
       })
   });
 });
+
+
 
 let backToTop = document.querySelector(".goto-top");
 

--- a/views/signup.ejs
+++ b/views/signup.ejs
@@ -18,11 +18,6 @@
             box-shadow: 0 7px 15px rgba(0, 0, 0, 0.5);
             transition: transform 0.3s ease, box-shadow 0.3s ease;
         }
-    
-        /* .form_body:hover {
-            transform: translateY(-5px);
-            box-shadow: 0 10px 20px rgba(0, 0, 0, 0.8);
-        } */
         .form-label {
             color: #ffffff;
         }
@@ -38,11 +33,6 @@
         .signup_form input[type="password"]::placeholder, 
         .signup_form input[type="email"]::placeholder {
             color: #aaaaaa;
-            /* border: 1px solid #555555; */
-            /* border-radius: 5px; */
-            /* padding: 12px; */
-            /* width: 100%; */
-            /* margin-top: 10px; */
         }
     }
     </style>
@@ -89,7 +79,7 @@
                 <label for="password" class="form-label">Confirm Password</label>
                 <br>
                 <div class="password-box">
-                    <input type="password" name="cnf-password" placeholder="Password" class="form-control" required>
+                    <input type="password" name="cnfPassword" placeholder="Password" class="form-control" required>
                     <i id="togglePassword" class="cnf-passkey passwordToggler fa fa-eye"></i> 
                 </div>
                 <div class="valid-feedback">


### PR DESCRIPTION
### Description
I add a backend logic to check whether both password field values are same or not. If not then flash a error message.
- This PR does the following:
  - Adds ... Backend logic to check both password value.


### Related Issues
Link any related issues using the format `Fixes #issue_number`. 
This helps to automatically close related issues when the PR is merged.
- Placeholder: "Fixes #264 "

### Screenshots (if applicable)
Add any screenshots that help explain or visualize the changes.

https://github.com/user-attachments/assets/a3ca538a-3173-4011-a4b2-950028e5b006


### Checklist
Make sure to check off all the items before submitting. Mark with [x] if done.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I am working on this issue under GSSOC


### @Soujanya2004   Marge it. And don't forget to add all the labels as per ISSUE #264 