### PR TITLE
Dark Mode for Manage Listings Page (#277)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "mongoose": "^8.7.0",
         "multer": "^1.4.5-lts.1",
         "multer-storage-cloudinary": "^4.0.0",
+        "nodemailer": "^6.9.16",
         "override": "^0.0.1",
         "passport": "^0.7.0",
         "passport-local": "^1.0.0",
@@ -1865,6 +1866,15 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.9.16",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.16.tgz",
+      "integrity": "sha512-psAuZdTIRN08HKVd/E8ObdV6NO7NTBY3KsC30F7M4H1OnmLCUNaS56FpYxyb26zWLSyYF9Ozch9KYHhHegsiOQ==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/normalize-package-data": {

--- a/views/adminDashboard.ejs
+++ b/views/adminDashboard.ejs
@@ -71,6 +71,56 @@
         padding: 0;
         margin: 3px;
     }
+
+    .dark-mode{
+      /* Table styles for dark mode */
+      table {
+          background-color: #1e1e1e;
+          color: #e0e0e0;
+      }
+
+      th {
+          background-color: #e12d4b;
+          color: #ffffff;
+      }
+
+      td, th {
+          border-color: #333;
+      }
+
+      tr:hover {
+          background-color: #333333;
+      }
+
+      /* Form, button, and icon styles */
+      input[type="search"], .form-control{
+          background-color: #333;
+          color: #e0e0e0;
+          border-color: #555;
+      }
+
+      input[type="search"]::placeholder {
+          color: #888;
+      }
+
+      
+
+      /* Other minor adjustments */
+      h1 {
+          color: #e0e0e0;
+      }
+
+      .dropdown-menu {
+          background-color: #2a2a2a;
+          border-color: #333;
+      }
+
+      .nav-link img.nav-provile {
+          border-radius: 50%;
+          border: 2px solid #e0e0e0;
+      }
+    }
+
        /* Responsive adjustments */
        @media (max-width: 995px) {
         table {


### PR DESCRIPTION
Fixes #277

This PR implements dark mode support for the Manage Listings page as requested in issue #277.

### Changes Implemented:
Adjusted the page to a darker color palette when dark mode is active, ensuring readability and a cohesive design across all components.
Modified tables, buttons, and text to align with the dark theme, providing a consistent user experience across both light and dark modes.

### Screenshots (if applicable)
![Screenshot (228)](https://github.com/user-attachments/assets/b00b7a62-8113-4f33-b453-697e7b778623)


### Checklist
Make sure to check off all the items before submitting. Mark with [x] if done.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I am working on this issue under GSSOC
