### PR TITLE
Dark Mode for Manage Users Page (#278)

### DIFF
--- a/views/manageUser.ejs
+++ b/views/manageUser.ejs
@@ -50,6 +50,31 @@
             padding: 0;
             margin: 3px;
         }
+
+        .dark-mode{
+            h1 {
+                color: #f1f1f1;
+            }
+            table {
+                background-color: #1e1e1e;
+                color: #e0e0e0;
+                border-color: #333333;
+            }
+
+            th {
+                background-color: #e12d4b;
+                color: #ffffff;
+            }
+
+            tr:nth-child(even) {
+                background-color: #2e2e2e;
+            }
+
+            tr:hover {
+                background-color: #444444;
+            }
+
+         }
         /* Responsive adjustments */
         @media (max-width: 995px) {
             table {


### PR DESCRIPTION
Fixes #278

This PR implements dark mode for the Manage Users page as outlined in issue #278.

### Changes Implemented:
Applied a dark color scheme for the entire Manage Users page when dark mode is activated.
Styled elements including user lists, buttons, and icons to align with the dark theme, ensuring clear readability and usability."


### Screenshots (if applicable)
![Screenshot (229)](https://github.com/user-attachments/assets/c7eabe99-db0e-4d82-aab6-fd926f0ad87b)


### Checklist
Make sure to check off all the items before submitting. Mark with [x] if done.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I am working on this issue under GSSOC
