### PR TITLE
Implement Dark Mode for "View Listing" Page in Admin Dashboard (#341)

### DIFF
--- a/views/view_manage_listing.ejs
+++ b/views/view_manage_listing.ejs
@@ -88,6 +88,43 @@
             justify-content: center;
             margin-top: 2rem;
         }
+
+        /* DARK-MODE */
+        .dark-mode{
+            .container.listing {
+                background-color: #1c1c1e;
+                color: #f5f5f7;
+                border-radius: 10px;
+                box-shadow: 0 10px 20px rgba(255, 255, 255, 0.1);
+            }
+
+            .container.listing h1 {
+                color: #f0f0f5;
+                border-bottom: 2px solid #444;
+            }
+
+            .container.listing p {
+                color: #e0e0e0;
+            }
+
+            .container.listing strong {
+                color: #d9d9d9;
+            }
+
+            .image-gallery {
+                border-radius: 8px;
+            }
+
+            .image-gallery img {
+                box-shadow: 0 4px 10px rgba(255, 255, 255, 0.1);
+                transition: transform 0.3s ease, box-shadow 0.3s ease;
+            }
+
+            .image-gallery img:hover {
+                transform: scale(1.01);
+                box-shadow: 0 8px 16px rgba(255, 255, 255, 0.15);
+            }
+        }
     </style>
 
     


### PR DESCRIPTION
Fixes #341

This PR resolves issue #341 by adding a dark mode theme to the "View Listing" page accessible from the admin dashboard. This update ensures a visually cohesive experience in dark mode across the admin dashboard pages, improving readability and accessibility in low-light conditions.

### Testing Instructions
Detailed instructions on how to test the changes. Include any setup needed and specific test cases.
1. Pull this branch.
2. Run `npm install` to install dependencies.
3. Run `npm test` to execute the test suite.
4. Verify that ...

### Screenshots (if applicable)
![Screenshot (252)](https://github.com/user-attachments/assets/8285efc8-ca59-4d28-97e9-f99992c2b533)

### Checklist
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I am working on this issue under GSSOC
