### PR TITLE
Dark Mode Implementation for Individual Listing's Review Page in Admin Dashboard (#345)

### DIFF
--- a/views/view_reviews.ejs
+++ b/views/view_reviews.ejs
@@ -118,6 +118,59 @@
             color: #888;
             font-style: italic;
         }
+
+        /* DARK MODE CSS */
+        .dark-mode{
+            /* Dark mode for container */
+            .listing {
+                background-color: #1f1f1f;
+                border: 1px solid #333;
+                box-shadow: 0 10px 20px rgba(0, 0, 0, 0.7);
+            }
+
+            /* Headings */
+            .listing h1 {
+                color: #ff6b6b;
+                border-bottom: 2px solid #333;
+            }
+
+            /* Paragraph and text styling */
+            .listing p,
+            .listing strong {
+                color: #b0b0b0;
+            }
+
+            /* Image Gallery styling */
+            .image-gallery img {
+                box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
+            }
+
+            /* Table styling for reviews */
+            .reviews-table {
+                background-color: #1f1f1f;
+                color: #e0e0e0;
+                border-color: #333;
+            }
+
+            .reviews-table th {
+                background-color: #333;
+            }
+
+            .reviews-table td {
+                border: 1px solid #444;
+            }
+
+            .review-author {
+                color: #ffb74d;
+            }
+
+            .reviews-title {
+                color: #e9ecef;
+            }
+            .no-reviews-message {
+                color: #888;
+            }
+        }
     </style>
 
     


### PR DESCRIPTION
Fixes #345

This PR addresses issue #345 by adding dark mode styling to the review page for individual listings, as accessed from the admin dashboard. This improvement enhances readability and ensures consistency across admin pages in dark mode, making it more user-friendly in low-light conditions.

### Testing Instructions
Detailed instructions on how to test the changes. Include any setup needed and specific test cases.
1. Pull this branch.
2. Run `npm install` to install dependencies.
3. Run `npm test` to execute the test suite.
4. Verify that ...

### Screenshots (if applicable)
![Screenshot (253)](https://github.com/user-attachments/assets/1bce1b18-3d45-4b25-b1e8-a86da392271b)


### Checklist
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I am working on this issue under GSSOC
