### PR TITLE
Remove Edit Button for Managing User Profiles (#376)

### DIFF
--- a/views/manageUser.ejs
+++ b/views/manageUser.ejs
@@ -213,15 +213,10 @@
                 <% users.forEach(user => { %> 
                     <tr>
                         <td><b><%= user.username %></b></td>
-                        <td><%= user.email %></td>
-                        <td><%= user.isAdmin ? 'Admin' : 'User' %></td>
+                        <td><i><%= user.email %></i></td>
+                        <td><b><%= user.isAdmin ? 'Admin' : 'User' %></b></td>
                         <td>
                             <div class="user_btn">
-                                <!-- Edit Form -->
-                            <form action="/admin/user/edit/<%= user._id %>" method="GET">
-                                <button type="submit" class="btn btn-outline-primary">Edit</button>
-                            </form>
-
                             <!-- Delete Form -->
                             <form action="/admin/user/<%= user._id %>?_method=DELETE" method="POST" onsubmit="return confirm('Are you sure you want to delete this user?');">
                                 <button type="submit" class="btn btn-outline-danger">Delete</button>


### PR DESCRIPTION
Fixes #376

This PR addresses issue #376 by removing the Edit button from the manage user profiles section in the admin dashboard. Since editing user profile information could pose privacy concerns, especially with potential fake users, this change enhances privacy by allowing only the delete option for user profiles.

### Testing Instructions
Detailed instructions on how to test the changes. Include any setup needed and specific test cases.
1. Pull this branch.
2. Run `npm install` to install dependencies.
3. Run `npm test` to execute the test suite.
4. Verify that ...

### Screenshots (if applicable)
![Screenshot (265)](https://github.com/user-attachments/assets/56c686dc-e417-438a-8e6b-51f975f5680d)


### Checklist
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I am working on this issue under GSSOC
