### PR TITLE
Fix the owner profile pic section in show page

### DIFF
--- a/views/show.ejs
+++ b/views/show.ejs
@@ -232,7 +232,14 @@
                         </p>
                         <p class="mt-2">
                             <% if (list.owner && list.owner.profilePicture && list.owner.profilePicture.purl) { %>
-                                <img src="<%= list.owner.profilePicture.purl %>" alt="User" class="owner-avatar">
+
+                                <!-- Set the low resolution for profile pic -->
+                                <%  
+                                    let normalURL = list.owner.profilePicture.purl;
+                                    let lowResURL =  normalURL.replace("/upload", "/upload/q_auto,e_blur:50,w_250,h_250");
+                                %>
+
+                                <img src="<%=lowResURL%>" alt="User" class="owner-avatar">
                             <% } else { %>
                                 <img src="/profile.png" alt="User" class="owner-avatar">
                             <% } %>


### PR DESCRIPTION
### Description
I fix the owner profile pic problem in show list page. Where I also set the low resolution rendering for reduce the loading time for the server.
- This PR does the following:
  - Fixes ... The list owner profile picture display section.

### Related Issues
Link any related issues using the format `Fixes #issue_number`. 
This helps to automatically close related issues when the PR is merged.
- Placeholder: "Fixes #328 "

### Screenshots (if applicable)
Add any screenshots that help explain or visualize the changes.
![image](https://github.com/user-attachments/assets/f05f462c-6587-4e3e-bcba-f0a3a0bfc5d7)
![image](https://github.com/user-attachments/assets/a1dc898a-8e27-4120-a1a8-f593a6897e3b)

### Additional Context
Any additional context or information that reviewers should be aware of.
- This PR is based on the following...
-  Here set the profile picture for different corresponding owner for each list,

### Checklist
Make sure to check off all the items before submitting. Mark with [x] if done.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I am working on this issue under GSSOC


### @Soujanya2004   Marge it. And don't forget to add all the labels as per ISSUE #328 