### PR TITLE
Display All Listings with Flash Message When No Results Found for Selected Filter (#439)

### DIFF
--- a/controllers/listing.js
+++ b/controllers/listing.js
@@ -31,6 +31,7 @@ module.exports.index = async (req, res) => {
             // If no listings are found for the tag, flash a message
             if (listings.length === 0) {
                 req.flash('error', `No listings found for the tag "${tag}".`);
+                return res.redirect("/listing");
             }
             
             // console.log(listings);


### PR DESCRIPTION
Fixes #439

This PR resolves issue #439 by implementing functionality that ensures users are notified when no listings match their selected filter criteria. Currently, a blank page is shown when no results are found, which can confuse users. With this update, the page will display all available listings by default, along with a flash message indicating that no results were found for the applied filter.

### Changes Made

- Modified the listing filter logic to check for empty results and, if no results match the filter, display all listings by default.
- Implemented a flash message to notify users that no listings matched their filter criteria.


### Testing Instructions
1. Pull this branch.
2. Run `npm install` to install dependencies.
3. Run `npm test` to execute the test suite.
4. Verify that ...

### Screenshots (if applicable)

https://github.com/user-attachments/assets/7c4c26b9-92f6-4e95-9bbe-03c863859f8b




### Checklist
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I am working on this issue under GSSOC
