### PR TITLE
 Display Listing Tags in Admin Dashboard for Better Tag Management (#441)

### DIFF
--- a/views/adminDashboard.ejs
+++ b/views/adminDashboard.ejs
@@ -84,7 +84,9 @@
         <div class="col col-md-1">Country</div>
         <div class="col col-md-1">Reviews</div>
         <div class="col-2 col-md-2">Images</div>
-        <div class="col col-md-2">Actions</div>
+        <!-- tags -->
+         <div class="col col-md-1">Tags</div>
+        <div class="col col-md-1">Actions</div>
     </div>
             <% listings.forEach(list => { %> <!-- Use forEach to iterate over listings -->
               <div class="row border-bottom p-2 listing-row">
@@ -109,7 +111,17 @@
                         <img src="<%= image.url %>" alt="<%= image.filename %>" class="img-fluid rounded me-1" style="width: 50px; height: auto;">
                     <% }) %>
                 </div>
-                <div class="col-12 col-md-2  all_btns">
+                <!-- tags -->
+                 <div class="col-12 col-md-1">
+                    <% if (list.tags && list.tags.length>0) { %>
+                      <% list.tags.forEach(tag => { %>
+                        <span class="badge bg-primary me-1"><%= tag %></span>
+                    <% }) %>
+                    <% } else{ %>
+                      <span class="badge bg-secondary me-1">No Tags</span>
+                    <% } %>
+                </div>
+                <div class="col-12 col-md-1  all_btns">
                         <!-- Edit Form -->
                         <form action="/admin/listing/edit/<%= list._id %>" method="GET">
                             <button class="btn btn-outline-primary" type="submit">Edit</button>


### PR DESCRIPTION
Fixes #441

This PR addresses issue #441 by adding a "Tags" column in the admin dashboard, allowing administrators to view the tags associated with each listing.

### Changes
- Added a new "Tags" column in the admin dashboard to display tags for each listing.
- Implemented logic to handle cases where a listing might have no tags or empty tags, ensuring the dashboard remains functional even when tags are missing.

### Testing Instructions
1. Pull this branch.
2. Run `npm install` to install dependencies.
3. Run `npm test` to execute the test suite.
4. Verify that ...

### Screenshots (if applicable)
![Screenshot (288)](https://github.com/user-attachments/assets/3145b154-1538-4ab3-92ec-773b7d29dcb7)




### Checklist
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I am working on this issue under GSSOC
