### PR TITLE
Display Tags on Individual Listings in User Account with Fallback for No Tags (#443)

### DIFF
--- a/views/adminDashboard.ejs
+++ b/views/adminDashboard.ejs
@@ -84,7 +84,9 @@
         <div class="col col-md-1">Country</div>
         <div class="col col-md-1">Reviews</div>
         <div class="col-2 col-md-2">Images</div>
-        <div class="col col-md-2">Actions</div>
+        <!-- tags -->
+         <div class="col col-md-1">Tags</div>
+        <div class="col col-md-1">Actions</div>
     </div>
             <% listings.forEach(list => { %> <!-- Use forEach to iterate over listings -->
               <div class="row border-bottom p-2 listing-row">
@@ -109,7 +111,17 @@
                         <img src="<%= image.url %>" alt="<%= image.filename %>" class="img-fluid rounded me-1" style="width: 50px; height: auto;">
                     <% }) %>
                 </div>
-                <div class="col-12 col-md-2  all_btns">
+                <!-- tags -->
+                 <div class="col-12 col-md-1">
+                    <% if (list.tags && list.tags.length>0) { %>
+                      <% list.tags.forEach(tag => { %>
+                        <span class="badge bg-primary me-1"><%= tag %></span>
+                    <% }) %>
+                    <% } else{ %>
+                      <span class="badge bg-secondary me-1">No Tags</span>
+                    <% } %>
+                </div>
+                <div class="col-12 col-md-1  all_btns">
                         <!-- Edit Form -->
                         <form action="/admin/listing/edit/<%= list._id %>" method="GET">
                             <button class="btn btn-outline-primary" type="submit">Edit</button>

--- a/views/show.ejs
+++ b/views/show.ejs
@@ -263,6 +263,19 @@
                         <p class="listing-location"><b>Country:</b>
                             <%=list.country%>
                         </p>
+                        <!-- tags -->
+                         <p>
+                            <% if (list.tags && list.tags.length>0) { %>
+                                <% list.tags.forEach(tag => { %>
+                                    <span class="badge bg-primary"><%= tag %></span>
+                                 <% }); %>
+                             <% } else {%>
+                                <i style="color: #b72a44;">
+                                     No tags found.
+                                </i>
+                            <% } %>
+                         </p>
+
                         <p class="mt-2">
                             <% if (list.owner && list.owner.profilePicture && list.owner.profilePicture.purl) { %>
 


### PR DESCRIPTION
Fixes #443

This PR addresses issue #443 by adding tag display functionality for individual listings within user accounts. Tags associated with each listing are now visible to users, helping them understand how their listings are categorized.

### Testing Instructions
1. Pull this branch.
2. Run `npm install` to install dependencies.
3. Run `npm test` to execute the test suite.
4. Verify that ...

### Screenshots (if applicable)
![Screenshot (295)](https://github.com/user-attachments/assets/1d2c18a8-d497-452f-adf9-5eb7ce7cc6f5)


### Checklist
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I am working on this issue under GSSOC
