### PR TITLE
Display feedback toggler for admin

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,7 +25,7 @@ const { isLoggedIn, isAdmin } = require("./middlewares/middleware.js");
 const {saveRedirectUrl}=require("./middlewares/middleware.js");
 const {isOwner,isAuthor}=require("./middlewares/middleware.js");
 const {index, newpost, createpost, editpost, saveEditpost,search, deletepost, showPost, bookinfFt, signup, likeListing }=require("./controllers/listing.js");
-const { dashboard, showuser, deleteUser, deleteListing, viewIndividualListing, viewListingReview, adminListEditRender, adminSaveEditList, showFeedbacks, deleteFeedback } = require("./controllers/admin.js")
+const { dashboard, showuser, deleteUser, deleteListing, viewIndividualListing, viewListingReview, adminListEditRender, adminSaveEditList, showFeedbacks, deleteFeedback, displayFeedback } = require("./controllers/admin.js")
 const { signupRender, siggnedUp, logout, forgotPassword, passwordResetLink, resetPasswordTokenGet, resetPasswordTokenPatch, updatePasswordGet, updatePasswordPost } = require("./controllers/user.js")
 const { viewProfile, profileGet, profilePost } = require("./controllers/profile.js");
 const { contactPage, aboutPage, termsPage, privacyPage, contributors } = require("./controllers/others.js")
@@ -138,6 +138,9 @@ app.put('/admin/listing/edit/:id',isLoggedIn, isAdmin, upload.array('listing[ima
 app.get('/admin/feedbacks', isLoggedIn, isAdmin, asyncwrap(showFeedbacks));
 
 app.delete('/admin/feedbacks/:id',isLoggedIn, isAdmin, asyncwrap(deleteFeedback));
+
+app.post('/admin/feedbacks/:id/toggleDisplay', isLoggedIn, isAdmin, asyncwrap(displayFeedback));
+
 
 // ADMIN
 // ADMIN

--- a/controllers/admin.js
+++ b/controllers/admin.js
@@ -189,3 +189,32 @@ module.exports.deleteFeedback = async (req, res) => {
       res.status(500).send('Error deleting user: ' + error.message);
   }
 };
+
+module.exports.displayFeedback = async(req, res) => {
+  try {
+    const feedback = await Feedback.findById(req.params.id);
+    if (!feedback) {
+        req.flash('error', 'Feedback not found.');
+        return res.redirect('/admin/feedbacks');
+    }
+    
+    // Toggle the display field
+    feedback.display = !feedback.display;
+    await feedback.save();
+    
+    // req.flash('success', `Feedback display set to ${feedback.display ? 'true' : 'false'}.`);
+
+    if(feedback.display){
+      req.flash('success', "This feedback displayed now in user end!");
+    }
+    else{
+      req.flash('success', "This feedback is hide now in user end!");
+    }
+
+    res.redirect('/admin/feedbacks');
+} catch (err) {
+    console.error(err);
+    req.flash('error', 'Could not toggle for display the feedback, try again latter!');
+    res.redirect('/admin/feedbacks');
+}
+}

--- a/views/manageFeedback.ejs
+++ b/views/manageFeedback.ejs
@@ -13,6 +13,9 @@
             background-color: #fff;
             box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
         }
+        tr{
+            width: 100%;
+        }
         th, td {
             padding: 12px;
             text-align: left;
@@ -23,6 +26,7 @@
             color: white;
             text-transform: uppercase;
             letter-spacing: 0.05em;
+            text-align: center;
         }
         tr:nth-child(even) {
             background-color: #fafafa;
@@ -32,8 +36,24 @@
         }   
         .btn {
             width: 70px;
-            padding: 0;
+            padding: 0.15rem 0.25rem;
             margin: 3px;
+            font-size: 0.8rem;
+        }
+        .green{
+            color: #1ae94a !important;
+        }
+        .red{
+            color: #e12d4b;
+        }
+        .user_btn{
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+        }
+        .btn-success{
+            background-color: #00af29;
         }
 
         .dark-mode{
@@ -91,13 +111,20 @@
                         <td><b><%= feedback.name %></b></td>
                         <td><%= feedback.rating %> ★</td>
                         <td><%= feedback.comment %></td>
-                        <td><%= feedback.submittedAt %></td>
-                        <td>
+                        <td><%= feedback.submittedAt %><td>
+                        
                             <div class="user_btn">
                                 <!-- Delete Form -->
                                 <form action="/admin/feedbacks/<%= feedback._id %>?_method=DELETE" method="POST" onsubmit="return confirm('Are you sure you want to delete this feedback?');">
                                     <button type="submit" class="btn btn-danger">Delete</button>
                                 </form>
+
+                                <form action="/admin/feedbacks/<%=feedback._id%>/toggleDisplay" method="POST">
+                                    <button type="submit" class="btn btn-success">
+                                        <%= feedback.display ? 'Hide It' : 'Display It' %>
+                                    </button>
+                                </form> 
+                                <i class="fa-solid <%= feedback.display ? 'fa-eye green' : 'fa-eye-slash red' %>"></i>
                             </div>
                         </td>
                         <!--  -->


### PR DESCRIPTION
### Description
I add a button to toggle the display and hide for feedback in admin page with full backend support
- This PR does the following:
  - Adds ...
  - Fixes ...
  - Updates ...

### Related Issues
Link any related issues using the format `Fixes #issue_number`. 
This helps to automatically close related issues when the PR is merged.
- Placeholder: "Fixes #353 "

### Screenshots (if applicable)
Add any screenshots that help explain or visualize the changes.

https://github.com/user-attachments/assets/e54136ad-bdaa-4841-af86-095466a8a3bb


### Checklist
Make sure to check off all the items before submitting. Mark with [x] if done.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I am working on this issue under GSSOC

### @Soujanya2004   Marge it. And don't forget to add all the labels as per ISSUE #353 