### PR TITLE
adding table of contents in privacy and t&c pages and enhancing them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
+node_modules/.env
 node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "multer": "^1.4.5-lts.1",
         "multer-storage-cloudinary": "^4.0.0",
         "nodemailer": "^6.9.16",
-        "nodemon": "^3.1.7",
         "override": "^0.0.1",
         "passport": "^0.7.0",
         "passport-local": "^1.0.0",
@@ -326,18 +325,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/anymatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/append-field": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
@@ -386,17 +373,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
       "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
-    },
-    "node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/bn.js": {
       "version": "4.12.0",
@@ -449,17 +425,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/bson": {
@@ -584,29 +549,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
       }
     },
     "node_modules/clone-response": {
@@ -1150,17 +1092,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/finalhandler": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
@@ -1227,19 +1158,6 @@
       "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==",
       "license": "ISC"
     },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -1284,17 +1202,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/gopd": {
@@ -1452,11 +1359,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ignore-by-default": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA=="
-    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -1483,17 +1385,6 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-core-module": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.0.tgz",
@@ -1506,33 +1397,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "node_modules/is-plain-obj": {
@@ -2020,73 +1884,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/nodemon": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.7.tgz",
-      "integrity": "sha512-hLj7fuMow6f0lbB0cD14Lz2xNjwsyruH251Pk4t/yIitCFJbmY1myuLlHm/q06aST4jg6EgAh74PIBBrRqpVAQ==",
-      "dependencies": {
-        "chokidar": "^3.5.2",
-        "debug": "^4",
-        "ignore-by-default": "^1.0.1",
-        "minimatch": "^3.1.2",
-        "pstree.remy": "^1.1.8",
-        "semver": "^7.5.3",
-        "simple-update-notifier": "^2.0.0",
-        "supports-color": "^5.5.0",
-        "touch": "^3.1.0",
-        "undefsafe": "^2.0.5"
-      },
-      "bin": {
-        "nodemon": "bin/nodemon.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nodemon"
-      }
-    },
-    "node_modules/nodemon/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/nodemon/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/nodemon/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "node_modules/nodemon/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/normalize-package-data": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
@@ -2099,14 +1896,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/normalize-url": {
@@ -2325,17 +2114,6 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
       "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
     },
-    "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -2352,11 +2130,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/pstree.remy": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
-      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w=="
     },
     "node_modules/pump": {
       "version": "3.0.0",
@@ -2531,17 +2304,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -2727,17 +2489,6 @@
       "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
       "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ=="
     },
-    "node_modules/simple-update-notifier": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
-      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
-      "dependencies": {
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
@@ -2837,17 +2588,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -2855,14 +2595,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/touch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
-      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
-      "bin": {
-        "nodetouch": "bin/nodetouch.js"
       }
     },
     "node_modules/tr46": {
@@ -2922,11 +2654,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/undefsafe": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
-      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA=="
     },
     "node_modules/undici-types": {
       "version": "6.11.1",

--- a/views/privacy.ejs
+++ b/views/privacy.ejs
@@ -1,171 +1,334 @@
 <% layout("/layouts/boilerplate") %>
 
 <style>
-    /* Styling for the content wrapper */
-    .content-wrapper {
-        max-width: 1000px;
-        margin: 0 auto;
-        padding: 20px;
-        background-color: #fff;
+  /* General Styling */
+  html {
+    scroll-behavior: smooth;
+  }
+
+  .content-wrapper {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 30px;
+    background-color: #ffffff;
+    box-shadow: 0px 6px 12px rgba(0, 0, 0, 0.15);
+    border-radius: 10px;
+    transition: background-color 0.3s, color 0.3s;
+    position: relative;
+  }
+
+  /* Styling for section headings */
+  h3.page-title {
+    text-align: center;
+    font-size: 36px;
+    font-weight: bold;
+    margin: 30px 0;
+    color: #333;
+    transition: color 0.3s;
+    position: relative;
+  }
+
+  h3.page-title::after {
+    content: "";
+    position: absolute;
+    bottom: -10px;
+    left: 0;
+    width: 100%;
+    height: 2px;
+    background-color: #0073e6;
+  }
+
+  /* Styling for section titles in TOC and sections */
+  .toc-section-title,
+  b {
+    font-size: 18px;
+    font-weight: bold;
+    color: #444;
+    transition: color 0.3s;
+  }
+
+  /* Styling for paragraphs with a custom class */
+  p.text-content,
+  li.text-item {
+    font-size: 17px;
+    line-height: 1.8;
+    color: #333;
+    margin-bottom: 10px;
+    transition: color 0.3s;
+    font-family: "Arial", sans-serif;
+  }
+
+  ul.custom-list {
+    list-style-type: disc;
+    margin-left: 25px;
+  }
+
+  /* Styling for each section */
+  section {
+    margin-bottom: 50px;
+    scroll-margin-top: 85px;
+  }
+
+  /* Table of contents styling */
+  .table-of-contents {
+    margin-right: 30px;
+    padding: 20px;
+    background-color: #f9f9f9;
+    border-radius: 10px;
+    border: 1px solid #ddd;
+    transition: background-color 0.3s, border-color 0.3s;
+    box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.1);
+  }
+
+  .table-of-contents ul {
+    list-style-type: none;
+    padding-left: 0;
+  }
+
+  .table-of-contents li {
+    padding: 6px 0;
+  }
+
+  /* Add a border around each item in the TOC */
+  .table-of-contents li.section-item {
+    border: 1px solid #ddd;
+    margin-bottom: 10px;
+    padding: 12px;
+    border-radius: 8px;
+    background-color: #f4f4f4;
+    transition: background-color 0.3s, border-color 0.3s;
+  }
+
+  .table-of-contents li.section-item:hover {
+    background-color: #e9e9e9;
+    border-color: #ccc;
+  }
+
+  /* Styling for links in the TOC */
+  .table-of-contents a {
+    color: #0073e6;
+    font-weight: 500;
+    text-decoration: none;
+    transition: color 0.3s;
+    font-size: 16px;
+  }
+
+  .table-of-contents a:hover {
+    text-decoration: underline;
+    color: #0056b3;
+  }
+
+  .table-of-contents li a.active {
+    font-weight: bold;
+    color: #0056b3;
+  }
+
+  /* Layout Styling */
+  .terms-container {
+    display: flex;
+    gap: 30px;
+  }
+
+  .toc {
+    width: 20%;
+    padding: 25px;
+    position: sticky;
+    top: 20px;
+    background-color: #f1f1f1;
+    height: 100vh;
+    overflow-y: auto;
+    border-right: 1px solid #ddd;
+    border-radius: 10px;
+    transition: background-color 0.3s, border-color 0.3s;
+    box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+  }
+
+  .terms-content {
+    width: 80%;
+    padding: 30px;
+    background-color: #ffffff;
+    border-radius: 10px;
+    box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.1);
+  }
+
+  /* Dark Mode */
+  .dark-mode {
+    background-color: #2b2b2b;
+  }
+
+  .dark-mode .content-wrapper {
+    background-color: #333;
+    color: #dfdfdf;
+  }
+
+  .dark-mode h3.page-title,
+  .dark-mode b,
+  .dark-mode p,
+  .dark-mode li {
+    color: #dfdfdf;
+  }
+
+  .dark-mode .table-of-contents {
+    background-color: #444;
+    border-color: #555;
+    color: white;
+  }
+
+  .dark-mode .table-of-contents a {
+    color: #66b2ff;
+  }
+
+  .dark-mode .table-of-contents li a.active {
+    color: #3399ff;
+  }
+
+  .dark-mode .table-of-contents a:hover {
+    color: #3385cc;
+  }
+
+  /* Media Query for Responsive Layout */
+  @media (max-width: 768px) {
+    .terms-container {
+      flex-direction: column;
+      gap: 20px;
     }
 
-    /* Styling for section headings (b) */
-    h3 {
-        font-size: 28px;
-        font-weight: bold;
-        margin-top: 1rem;
-        color: #646464;
-        margin-bottom: 10px;
-        text-align: left;
-    }
-    /* Styling for paragraphs and list items */
-    p, li {
-        font-size: 16px;
-        line-height: 1.6;
-        color: #333;
+    .toc {
+      width: 100%;
+      order: 1;
+      border-right: none;
+      border-bottom: 1px solid #ddd;
     }
 
-    /* Styling for unordered lists */
-    ul {
-        list-style-type: disc;
-        margin-left: 20px;
+    .terms-content {
+      width: 100%;
+      order: 2;
     }
-
-    /* Styling for each section */
-    section {
-        margin-bottom: 40px;
-    }
-
-    /* Center the page title */
-    b.page-title {
-        text-align: center;
-        font-size: 32px;
-    }
-
-    /* DARKMODE CSS */
-    .dark-mode {
-        h3{
-            color: #dfdfdf;
-        }
-        b {
-            color: #f7f7f7;
-        } 
-        p , li {
-            color: #dfdfdf;
-        }
-   
-        .content-wrapper {
-            background-color: transparent;
-        }
-
-    } 
+  }
 </style>
 
 <body>
-    <!-- Page Title -->
-    <h3 class="page-title" style="text-align: center;">Privacy Policy</h3>
+  <!-- Page Title -->
+  <h3 class="page-title" style="text-align: center">Privacy Policy</h3>
 
-    <!-- Main Content Wrapper -->
-    <div class="content-wrapper">
-
-        <!-- Section 1: Introduction -->
-        <section>
-            <b>1. Introduction</b>
-            <p>At Wanderlust, we are committed to protecting your privacy. This Privacy Policy explains how we collect, use, disclose, and protect your personal information when you use our platform. By using Wanderlust, you consent to the practices described in this policy.</p>
-        </section>
-
-        <!-- Section 2: Information We Collect -->
-        <section>
-            <b>2. Information We Collect</b>
-            <p>We collect the following types of information to provide you with a better experience on Wanderlust:</p>
-            <ul>
-                <li><strong>Personal Information:</strong> This includes your name, email address, phone number, and payment information, which you provide when you create an account or make a booking.</li>
-                <li><strong>Non-Personal Information:</strong> This includes browser type, device information, IP address, and usage data collected through cookies and similar technologies.</li>
-                <li><strong>Booking Details:</strong> Information related to your bookings, including property preferences, travel dates, and special requests.</li>
-            </ul>
-        </section>
-
-        <!-- Section 3: How We Use Your Information -->
-        <section>
-            <b>3. How We Use Your Information</b>
-            <p>Wanderlust uses your personal information for the following purposes:</p>
-            <ul>
-                <li><strong>To provide services:</strong> We use your personal information to create your account, process bookings, and communicate with you about your reservations.</li>
-                <li><strong>To improve our platform:</strong> We analyze non-personal information to understand user behavior and improve our services.</li>
-                <li><strong>Marketing communications:</strong> With your consent, we may send you promotional emails or offers based on your preferences.</li>
-                <li><strong>To ensure security:</strong> We use your information to detect and prevent fraud or unauthorized access to the platform.</li>
-            </ul>
-        </section>
-
-        <!-- Section 4: Sharing Your Information -->
-        <section>
-            <b>4. Sharing Your Information</b>
-            <p>Wanderlust does not sell or rent your personal information to third parties. However, we may share your information in the following circumstances:</p>
-            <ul>
-                <li><strong>With Hosts:</strong> When you make a booking, we share relevant details with the Host to facilitate your stay (e.g., your name, contact information, and special requests).</li>
-                <li><strong>Service Providers:</strong> We may share your information with third-party service providers who help us operate the platform, such as payment processors, customer support, or email delivery services.</li>
-                <li><strong>Legal Requirements:</strong> We may disclose your information if required to do so by law or if we believe such disclosure is necessary to protect our rights, comply with legal processes, or prevent harm.</li>
-            </ul>
-        </section>
-
-        <!-- Section 5: Cookies and Tracking Technologies -->
-        <section>
-            <b>5. Cookies and Tracking Technologies</b>
-            <p>Wanderlust uses cookies and similar technologies to improve user experience and analyze site performance. Cookies are small data files stored on your device that help us remember your preferences and recognize you on future visits. You can manage your cookie preferences through your browser settings.</p>
-        </section>
-
-        <!-- Section 6: Data Security -->
-        <section>
-            <b>6. Data Security</b>
-            <p>We take the security of your personal information seriously and implement reasonable technical and organizational measures to protect it. However, no method of transmission over the internet or electronic storage is completely secure. While we strive to use commercially acceptable means to protect your personal information, we cannot guarantee its absolute security.</p>
-        </section>
-
-        <!-- Section 7: Your Rights -->
-        <section>
-            <b>7. Your Rights</b>
-            <p>You have certain rights regarding your personal information, including:</p>
-            <ul>
-                <li><strong>Access and Correction:</strong> You can access and update your personal information by logging into your account.</li>
-                <li><strong>Deletion:</strong> You may request the deletion of your personal data, subject to certain legal obligations we may have.</li>
-                <li><strong>Data Portability:</strong> You may request a copy of your data in a structured, machine-readable format.</li>
-                <li><strong>Withdrawal of Consent:</strong> If you have provided consent for marketing communications, you may withdraw it at any time by following the unsubscribe instructions in our emails.</li>
-            </ul>
-        </section>
-
-        <!-- Section 8: Data Retention -->
-        <section>
-            <b>8. Data Retention</b>
-            <p>We retain your personal information for as long as necessary to fulfill the purposes for which it was collected, or as required by law. Once your data is no longer needed, we securely delete or anonymize it.</p>
-        </section>
-
-        <!-- Section 9: International Data Transfers -->
-        <section>
-            <b>9. International Data Transfers</b>
-            <p>Wanderlust operates globally, and your information may be transferred to and processed in countries outside of your own. We take steps to ensure that your personal information is protected in accordance with this Privacy Policy and applicable laws when transferred internationally.</p>
-        </section>
-
-        <!-- Section 10: Children's Privacy -->
-        <section>
-            <b>10. Children's Privacy</b>
-            <p>Wanderlust is not intended for children under the age of 18, and we do not knowingly collect personal information from children. If you believe that a child has provided us with personal information, please contact us, and we will take steps to delete such information.</p>
-        </section>
-
-        <!-- Section 11: Changes to This Privacy Policy -->
-        <section>
-            <b>11. Changes to This Privacy Policy</b>
-            <p>We may update this Privacy Policy from time to time. When we make changes, we will post the updated policy on this page and update the "Last Updated" date at the top. Your continued use of Wanderlust after any changes constitutes your acceptance of the updated Privacy Policy.</p>
-        </section>
-
-        <!-- Section 12: Contact Us -->
-        <section>
-            <b>12. Contact Us</b>
-            <p>If you have any questions or concerns about this Privacy Policy or our data practices, please contact us at:</p>
-            <ul>
-                <li>Email: <b>support@wanderlust.com</b></li>
-                <li>Phone: <b>+123-456-7890</b></li>
-                <li>Address: <b>123 Wanderlust Avenue, Dream City, Wonderland, 12345</b></li>
-            </ul>
-        </section>
-
+  <div class="terms-container">
+    <!-- Table of Contents on the left -->
+    <div class="table-of-contents">
+      <h3>Table of Contents</h3>
+      <ul>
+        <li><a href="#intro">1. Introduction</a></li>
+        <li><a href="#info-collect">2. Information We Collect</a></li>
+        <li><a href="#how-use">3. How We Use Your Information</a></li>
+        <li><a href="#share-info">4. Sharing Your Information</a></li>
+        <li><a href="#cookies">5. Cookies and Tracking Technologies</a></li>
+        <li><a href="#security">6. Data Security</a></li>
+        <li><a href="#rights">7. Your Rights</a></li>
+        <li><a href="#retention">8. Data Retention</a></li>
+        <li><a href="#international">9. International Data Transfers</a></li>
+        <li><a href="#children">10. Children's Privacy</a></li>
+        <li><a href="#changes">11. Changes to This Privacy Policy</a></li>
+        <li><a href="#contact">12. Contact Us</a></li>
+    </ul>
     </div>
+
+  <!-- Main Content Wrapper -->
+  <div class="content-wrapper">
+    <!-- Section 1: Introduction -->
+    <section id="introduction">
+      <b>1. Introduction</b>
+      <p>
+        At Wanderlust, we are committed to protecting your privacy. This Privacy
+        Policy explains how we collect, use, disclose, and protect your personal
+        information when you use our platform. By using Wanderlust, you consent
+        to the practices described in this policy.
+      </p>
+    </section>
+
+    <!-- Section 2: Information We Collect -->
+    <section id="info-collect">
+        <b>2. Information We Collect</b>
+        <p>We collect the following types of information to provide you with a better experience on Wanderlust:</p>
+        <ul>
+            <li><strong>Personal Information:</strong> This includes your name, email address, phone number, and payment information, which you provide when you create an account or make a booking.</li>
+            <li><strong>Non-Personal Information:</strong> This includes browser type, device information, IP address, and usage data collected through cookies and similar technologies.</li>
+            <li><strong>Booking Details:</strong> Information related to your bookings, including property preferences, travel dates, and special requests.</li>
+        </ul>
+    </section>
+
+    <!-- Section 3: How We Use Your Information -->
+    <section id="how-use">
+        <b>3. How We Use Your Information</b>
+        <p>Wanderlust uses your personal information for the following purposes:</p>
+        <ul>
+            <li><strong>To provide services:</strong> We use your personal information to create your account, process bookings, and communicate with you about your reservations.</li>
+            <li><strong>To improve our platform:</strong> We analyze non-personal information to understand user behavior and improve our services.</li>
+            <li><strong>Marketing communications:</strong> With your consent, we may send you promotional emails or offers based on your preferences.</li>
+            <li><strong>To ensure security:</strong> We use your information to detect and prevent fraud or unauthorized access to the platform.</li>
+        </ul>
+    </section>
+
+    <!-- Section 4: Sharing Your Information -->
+    <section id="share-info">
+        <b>4. Sharing Your Information</b>
+        <p>Wanderlust does not sell or rent your personal information to third parties. However, we may share your information in the following circumstances:</p>
+        <ul>
+            <li><strong>With Hosts:</strong> When you make a booking, we share relevant details with the Host to facilitate your stay (e.g., your name, contact information, and special requests).</li>
+            <li><strong>Service Providers:</strong> We may share your information with third-party service providers who help us operate the platform, such as payment processors, customer support, or email delivery services.</li>
+            <li><strong>Legal Requirements:</strong> We may disclose your information if required to do so by law or if we believe such disclosure is necessary to protect our rights, comply with legal processes, or prevent harm.</li>
+        </ul>
+    </section>
+
+    <!-- Section 5: Cookies and Tracking Technologies -->
+    <section id="cookies">
+        <b>5. Cookies and Tracking Technologies</b>
+        <p>We use cookies and similar tracking technologies to enhance your experience on Wanderlust. Cookies are small data files stored on your device that help us recognize your preferences and activity. You can control cookies through your browser settings.</p>
+    </section>
+
+    <!-- Section 6: Data Security -->
+    <section id="security">
+        <b>6. Data Security</b>
+        <p>We implement robust security measures to protect your personal information. While we strive to use commercially acceptable means to protect your data, no method of transmission over the internet or electronic storage is 100% secure.</p>
+    </section>
+
+    <!-- Section 7: Your Rights -->
+    <section id="rights">
+        <b>7. Your Rights</b>
+        <p>You have the right to access, update, and delete your personal information at any time. If you wish to exercise any of these rights, please contact us using the information provided below.</p>
+    </section>
+
+    <!-- Section 8: Data Retention -->
+    <section id="retention">
+        <b>8. Data Retention</b>
+        <p>We retain your personal information only for as long as necessary to fulfill the purposes outlined in this Privacy Policy unless a longer retention period is required or permitted by law.</p>
+    </section>
+
+    <!-- Section 9: International Data Transfers -->
+    <section id="international">
+        <b>9. International Data Transfers</b>
+        <p>Your personal information may be transferred to and processed in countries outside your country of residence. We ensure that appropriate safeguards are in place to protect your information during international transfers.</p>
+    </section>
+
+    <!-- Section 10: Children's Privacy -->
+    <section id="children">
+        <b>10. Children's Privacy</b>
+        <p>Wanderlust does not knowingly collect personal information from children under the age of 13. If we learn that we have inadvertently collected such information, we will delete it as soon as possible.</p>
+    </section>
+
+    <!-- Section 11: Changes to This Privacy Policy -->
+    <section id="changes">
+        <b>11. Changes to This Privacy Policy</b>
+        <p>We reserve the right to update this Privacy Policy at any time. When we make changes, we will revise the "Last Updated" date at the top of this page. We encourage you to review this Privacy Policy periodically to stay informed about our practices.</p>
+    </section>
+
+    <!-- Section 12: Contact Us -->
+    <section id="contact">
+        <b>12. Contact Us</b>
+        <p>If you have any questions or concerns about this Privacy Policy or your personal information, please contact us at:</p>
+        <ul>
+            <li>Email: privacy@wanderlust.com</li>
+            <li>Phone: 123-456-7890</li>
+            <li>Address: 123 Wanderlust Lane, Travel City, TC 56789</li>
+        </ul>
+    </section>
+  </div>
 </body>

--- a/views/terms.ejs
+++ b/views/terms.ejs
@@ -1,195 +1,516 @@
 <% layout("/layouts/boilerplate") %>
 
-    <style>
+<style>
+/* General Styling */
+html {
+    scroll-behavior: smooth;
+}
+
 .content-wrapper {
-        max-width: 1000px;
-        margin: 0 auto;
-        padding: 20px;
-        background-color: #fff;
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 30px;
+    background-color: #ffffff;
+    box-shadow: 0px 6px 12px rgba(0, 0, 0, 0.15);
+    border-radius: 10px;
+    transition: background-color 0.3s, color 0.3s;
+    position: relative;
+}
+
+/* Styling for section headings */
+h3.page-title {
+    text-align: center;
+    font-size: 36px;
+    font-weight: bold;
+    margin: 30px 0;
+    color: #333;
+    transition: color 0.3s;
+    position: relative;
+}
+
+h3.page-title::after {
+    content: '';
+    position: absolute;
+    bottom: -10px;
+    left: 0;
+    width: 100%;
+    height: 2px;
+    background-color: #0073e6;
+}
+
+/* Styling for section titles in TOC and sections */
+.toc-section-title, b {
+    font-size: 18px;
+    font-weight: bold;
+    color: #444;
+    transition: color 0.3s;
+}
+
+/* Styling for paragraphs with a custom class */
+p.text-content, li.text-item {
+    font-size: 17px;
+    line-height: 1.8;
+    color: #333;
+    margin-bottom: 10px;
+    transition: color 0.3s;
+    font-family: 'Arial', sans-serif;
+}
+
+ul.custom-list {
+    list-style-type: disc;
+    margin-left: 25px;
+}
+
+/* Styling for each section */
+section {
+    margin-bottom: 50px;
+    scroll-margin-top: 85px;
+}
+
+/* Table of contents styling */
+.table-of-contents {
+    margin-right: 30px;
+    padding: 20px;
+    background-color: #f9f9f9;
+    border-radius: 10px;
+    border: 1px solid #ddd;
+    transition: background-color 0.3s, border-color 0.3s;
+    box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.table-of-contents ul {
+    list-style-type: none;
+    padding-left: 0;
+}
+
+.table-of-contents li {
+    padding: 6px 0;
+}
+
+/* Add a border around each item in the TOC */
+.table-of-contents li.section-item {
+    border: 1px solid #ddd;
+    margin-bottom: 10px;
+    padding: 12px;
+    border-radius: 8px;
+    background-color: #f4f4f4;
+    transition: background-color 0.3s, border-color 0.3s;
+}
+
+.table-of-contents li.section-item:hover {
+    background-color: #e9e9e9;
+    border-color: #ccc;
+}
+
+/* Styling for links in the TOC */
+.table-of-contents a {
+    color: #0073e6;
+    font-weight: 500;
+    text-decoration: none;
+    transition: color 0.3s;
+    font-size: 16px;
+}
+
+.table-of-contents a:hover {
+    text-decoration: underline;
+    color: #0056b3;
+}
+
+.table-of-contents li a.active {
+    font-weight: bold;
+    color: #0056b3;
+}
+
+/* Layout Styling */
+.terms-container {
+    display: flex;
+    gap: 30px;
+}
+
+.toc {
+    width: 20%;
+    padding: 25px;
+    position: sticky;
+    top: 20px;
+    background-color: #f1f1f1;
+    height: 100vh;
+    overflow-y: auto;
+    border-right: 1px solid #ddd;
+    border-radius: 10px;
+    transition: background-color 0.3s, border-color 0.3s;
+    box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.terms-content {
+    width: 80%;
+    padding: 30px;
+    background-color: #ffffff;
+    border-radius: 10px;
+    box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+/* Dark Mode */
+.dark-mode {
+    background-color: #2b2b2b;
+}
+
+.dark-mode .content-wrapper {
+    background-color: #333;
+    color: #dfdfdf;
+}
+
+.dark-mode h3.page-title, 
+.dark-mode b, 
+.dark-mode p, 
+.dark-mode li {
+    color: #dfdfdf;
+}
+
+.dark-mode .table-of-contents {
+    background-color: #444;
+    border-color: #555;
+    color:white;
+}
+
+.dark-mode .table-of-contents a {
+    color: #66b2ff;
+}
+
+.dark-mode .table-of-contents li a.active {
+    color: #3399ff;
+}
+
+.dark-mode .table-of-contents a:hover {
+    color: #3385cc;
+}
+
+/* Media Query for Responsive Layout */
+@media (max-width: 768px) {
+    .terms-container {
+        flex-direction: column;
+        gap: 20px;
     }
 
-    /* Styling for section headings (h3) */
-    h3 {
-        font-size: 28px;
-        font-weight: bold;
-        margin-top: 1rem;
-        color: #646464;
-        margin-bottom: 10px;
-        text-align: left;
+    .toc {
+        width: 100%;
+        order: 1;
+        border-right: none;
+        border-bottom: 1px solid #ddd;
     }
 
-    /* Styling for paragraphs and list items */
-    p, li {
-        font-size: 16px;
-        line-height: 1.6;
-        color: #333;
+    .terms-content {
+        width: 100%;
+        order: 2;
     }
+}
 
-    /* Styling for unordered lists */
-    ul {
-        list-style-type: disc;
-        margin-left: 20px;
-    }
 
-    /* Styling for each section */
-    section {
-        margin-bottom: 40px;
-    }
 
-    /* Center the page title */
-    h3.page-title {
-        text-align: center;
-        font-size: 32px;
-    }
 
-     /* DARKMODE CSS */
-     .dark-mode {
-        h3{
-            color: #dfdfdf;
-        }
-        b {
-            color: #f7f7f7;
-        } 
-        p , li {
-            color: #dfdfdf;
-        }
-   
-        .content-wrapper {
-            background-color: transparent;
-        }
 
-    } 
 </style>
+
 <body>
-    <h3 style="text-align: center;">Terms and Conditions</h3>
-
-    <div class="content-wrapper">
-        <section>
-            <b>1. Introduction</b>
-            <p>Welcome to Wanderlust! These Terms and Conditions ("Terms") govern your use of our platform. By accessing or using the Wanderlust website, mobile application, or services, you agree to these Terms. Please review them carefully.</p>
+    <h3 class="page-title">Terms and Conditions</h3>
+  
+    <div class="terms-container">
+      <!-- Table of Contents on the left -->
+      <div class="table-of-contents">
+        <h3>Table of Contents</h3>
+        <ul>
+          <li><a href="#introduction">1. Introduction</a></li>
+          <li><a href="#definitions">2. Definitions</a></li>
+          <li><a href="#account-registration">3. Account Registration</a></li>
+          <li><a href="#listing-and-modification">4. Listing and Modification</a></li>
+          <li><a href="#availability-and-pricing">5. Availability and Pricing</a></li>
+          <li><a href="#security">6. Security</a></li>
+          <li><a href="#booking-and-payment">7. Booking and Payment</a></li>
+          <li><a href="#property-cancellation-and-refunds">8. Property Cancellation and Refunds</a></li>
+          <li><a href="#host-responsibilities">9. Host Responsibilities</a></li>
+          <li><a href="#guest-responsibilities">10. Guest Responsibilities</a></li>
+          <li><a href="#service-fees">11. Service Fees</a></li>
+          <li><a href="#taxes">12. Taxes</a></li>
+          <li><a href="#prohibited-activities">13. Prohibited Activities</a></li>
+          <li><a href="#dispute-resolution">14. Dispute Resolution</a></li>
+          <li><a href="#indemnification">15. Indemnification</a></li>
+          <li><a href="#limitation-of-liability">16. Limitation of Liability</a></li>
+          <li><a href="#governing-law-and-jurisdiction">17. Governing Law and Jurisdiction</a></li>
+          <li><a href="#intellectual-property">18. Intellectual Property</a></li>
+          <li><a href="#privacy">19. Privacy</a></li>
+          <li><a href="#termination">20. Termination</a></li>
+          <li><a href="#amendments">21. Amendments</a></li>
+          <li><a href="#contact-us">22. Contact Us</a></li>
+        </ul>
+      </div>
+  
+      <!-- Terms and Conditions Content on the right -->
+      <div class="content-wrapper">
+        <section id="introduction">
+          <b>1. Introduction</b>
+          <p>
+            Welcome to Wanderlust! These Terms and Conditions ("Terms") govern your
+            use of our platform. By accessing or using the Wanderlust website,
+            mobile application, or services, you agree to these Terms. Please review
+            them carefully.
+          </p>
         </section>
-    
-        <section>
-            <b>2. Definitions</b>
-            <p>In these Terms:</p>
-            <ul>
-                <li><strong>"Platform"</strong> refers to Wanderlust’s website, mobile app, and associated services.</li>
-                <li><strong>"Host"</strong> refers to anyone who lists their property on Wanderlust.</li>
-                <li><strong>"Guest"</strong> refers to anyone who books a property through Wanderlust.</li>
-                <li><strong>"Property"</strong> refers to accommodations listed by Hosts on the platform.</li>
-            </ul>
-        </section>
-    
-        <section>
-            <b>3. Account Registration</b>
-            <p>To use certain features of the Platform, you must create an account. You agree to provide accurate, current, and complete information during registration and to update such information to keep it accurate. You are responsible for safeguarding your account credentials and for all activities conducted under your account.</p>
-        </section>
-    
-        <section>
-            <b>4. Listing and Modification</b>
-            <p>You agree to list your property on the Platform in a way that accurately reflects the property's location, amenities, and pricing. You are responsible for ensuring that your listing is up-to-date and remains accurate. Wanderlust may modify or remove your listing at any time, without prior notice, if the property is no longer available or is no longer suitable for rental.</p>
-        </section>
-    
-        <section>
-            <b>5. Availability and Pricing</b>
-            <p>Wanderlust provides a flexible booking system that allows Guests to book properties for a specified number of nights and a specified number of guests. Guests can book properties with a minimum of 1 night and a maximum of 7 nights. Pricing is determined by the Host and may vary based on factors such as property location, amenities, and guest preferences. Wanderlust may offer special discounts or promotions to Guests during peak seasons or during certain events.</p>
-        </section>
-    
-        <section>
-            <b>6. Security</b>
-            <p>Wanderlust takes all necessary measures to protect your account and property information. We use strong, unique encryption algorithms to protect your data. However, please be aware that no security system is foolproof, and we cannot guarantee that your account and property information will remain secure in the event of a breach.</p>
-        </section>
-    
-        <section>
-            <b>7. Booking and Payment</b>
-            <p>When Guests book a property, they are entering into a legal agreement with the Host. Wanderlust acts solely as an intermediary and is not responsible for the properties listed. Payment processing is handled by third-party providers, and service fees may apply. Bookings are confirmed upon receipt of payment.</p>
-        </section>
-    
-        <section>
-            <b>8. Property Cancellation and Refunds</b>
-            <p>Guests may cancel their bookings at any time, with or without notice, provided that the cancellation occurs within 24 hours of the booking. If a Guest cancels their booking, they will be charged a cancellation fee of 10% of the total booking price. Wanderlust will issue a full refund to the Guest within 72 hours of the cancellation. If a Guest cancels their booking after 24 hours, they will be charged a cancellation fee of 20% of the total booking price. Wanderlust will issue a partial refund to the Guest within 48 hours of the cancellation.</p>
-        </section>
-    
-        <section>
-            <b>9. Host Responsibilities</b>
-            <p>As a Host, you are responsible for ensuring that your property is as described in the listing, complies with local laws, and is safe for Guests. You are also responsible for addressing any issues that arise during a Guest's stay. All listings must be accurate, including pricing, availability, and amenities.</p>
-        </section>
-    
-        <section>
-            <b>10. Guest Responsibilities</b>
-            <p>As a Guest, you agree to follow the Host’s house rules, respect the property, and comply with all applicable laws during your stay. You will be held responsible for any damages to the property caused by you or your invitees.</p>
-        </section>
-    
-        <section>
-            <b>11. Service Fees</b>
-            <p>Wanderlust charges service fees to both Hosts and Guests for using the platform. These fees are non-refundable and are displayed at the time of booking or listing. Fees help maintain the platform and cover operational costs.</p>
-        </section>
-    
-        <section>
-            <b>12. Taxes</b>
-            <p>Hosts are responsible for determining and fulfilling their tax obligations related to the rental income generated from the platform. Wanderlust may provide tax documentation as required but is not responsible for withholding or remitting taxes on behalf of the Hosts.</p>
-        </section>
-    
-        <section>
-            <b>13. Prohibited Activities</b>
-            <p>Users agree not to:</p>
-            <ul>
-                <li>Violate any applicable laws or regulations.</li>
-                <li>Post false, misleading, or fraudulent information.</li>
-                <li>Interfere with the operation of the platform or engage in disruptive activities.</li>
-                <li>Discriminate against other users based on race, religion, nationality, disability, or any other protected category.</li>
-            </ul>
-        </section>
-    
-        <section>
-            <b>14. Dispute Resolution</b>
-            <p>In the event of a dispute between Guests and Hosts, Wanderlust may facilitate communication but is not responsible for resolving conflicts. We recommend that both parties attempt to resolve disputes amicably before pursuing further action. In cases where mediation is required, each party is responsible for its own legal costs.</p>
-        </section>
-    
-        <section>
-            <b>15. Indemnification</b>
-            <p>You agree to indemnify and hold Wanderlust, its affiliates, and its subsidiaries, officers, employees, agents, and contractors, harmless from any and all claims, losses, damages, liabilities, and expenses, including reasonable attorney's fees, arising out of or related to your use of the Platform, your violation of these Terms, or your violation of any third-party rights. You also agree to waive your right to sue in your state or federal court.</p>
-        </section>
-    
-        <section>
-            <b>16. Limitation of Liability</b>
-            <p>In no event shall Wanderlust, its affiliates, or its subsidiaries, officers, employees, agents, or contractors be liable for any damages, losses, or injuries, including, without limitation, any direct, indirect, punitive, special, incidental, or consequential damages, arising out of or related to the Platform, your use of the Platform, your violation of these Terms, or your violation of any third-party rights. This limitation of liability shall apply to the extent permitted by law, and you acknowledge that you have the right to seek injunctive relief in any court of competent jurisdiction.</p>
-        </section>
-    
-        <section>
-            <b>17. Governing Law and Jurisdiction</b>
-            <p>These Terms are governed by the laws of the State of California, without regard to its conflict of law provisions. You agree that any disputes arising out of or related to these Terms or your use of the Platform will be resolved in Santa Clara County, California, by a court of competent jurisdiction. If you reside outside of California, you consent to the jurisdiction and venue of the California Supreme Court.</p>
-        </section>
-    
-        <section>
-            <b>18. Intellectual Property</b>
-            <p>All content, including text, images, and software used on the platform, is the intellectual property of Wanderlust or its licensors. You may not copy, modify, or distribute any content from the platform without prior written consent from Wanderlust.</p>
-        </section>
-    
-        <section>
-            <b>19. Privacy</b>
-            <p>Your use of the Wanderlust platform is also governed by our Privacy Policy. We collect and process personal information in accordance with our Privacy Policy, which can be found.</p>
-        </section>
-    
-        <section>
-            <b>20. Termination</b>
-            <p>Wanderlust reserves the right to suspend or terminate your account at any time if you violate these Terms or engage in prohibited activities. Upon termination, you must cease all use of the platform and any outstanding payments remain due.</p>
-        </section>
-    
-        <section>
-            <b>21. Amendments</b>
-            <p>We reserve the right to modify these Terms at any time. Any changes will be effective immediately upon posting. You will be notified of significant changes, and your continued use of the platform signifies acceptance of the updated Terms.</p>
+  
+        <section id="definitions">
+          <b>2. Definitions</b>
+          <p>In these Terms:</p>
+          <ul>
+            <li>
+              <strong>"Platform"</strong> refers to Wanderlust’s website, mobile
+              app, and associated services.
+            </li>
+            <li>
+              <strong>"Host"</strong> refers to anyone who lists their property on
+              Wanderlust.
+            </li>
+            <li>
+              <strong>"Guest"</strong> refers to anyone who books a property through
+              Wanderlust.
+            </li>
+            <li>
+              <strong>"Property"</strong> refers to accommodations listed by Hosts
+              on the platform.
+            </li>
+          </ul>
         </section>
 
-        <section>
-            <b>22. Contact Us</b>
-            <p>If you have any questions about these Terms or require further information, please contact us at:</p>
-            <ul>
-                <li>Email: <b>support@wanderlust.com</b></li>
-                <li>Phone: <b>+123-456-7890</b></li>
-                <li>Address: <b>123 Wanderlust Avenue, Dream City, Wonderland, 12345</b></li>
-            </ul>
-        </section>
-    </div>
-   
+    <section id="account-registration">
+      <b>3. Account Registration</b>
+      <p>
+        To use certain features of the Platform, you must create an account. You
+        agree to provide accurate, current, and complete information during
+        registration and to update such information to keep it accurate. You are
+        responsible for safeguarding your account credentials and for all
+        activities conducted under your account.
+      </p>
+    </section>
+
+    <section id="listing-and-modification">
+      <b>4. Listing and Modification</b>
+      <p>
+        You agree to list your property on the Platform in a way that accurately
+        reflects the property's location, amenities, and pricing. You are
+        responsible for ensuring that your listing is up-to-date and remains
+        accurate. Wanderlust may modify or remove your listing at any time,
+        without prior notice, if the property is no longer available or is no
+        longer suitable for rental.
+      </p>
+    </section>
+
+    <section id="availability-and-pricing">
+      <b>5. Availability and Pricing</b>
+      <p>
+        Wanderlust provides a flexible booking system that allows Guests to book
+        properties for a specified number of nights and a specified number of
+        guests. Guests can book properties with a minimum of 1 night and a
+        maximum of 7 nights. Pricing is determined by the Host and may vary
+        based on factors such as property location, amenities, and guest
+        preferences. Wanderlust may offer special discounts or promotions to
+        Guests during peak seasons or during certain events.
+      </p>
+    </section>
+
+    <section id="security">
+      <b>6. Security</b>
+      <p>
+        Wanderlust takes all necessary measures to protect your account and
+        property information. We use strong, unique encryption algorithms to
+        protect your data. However, please be aware that no security system is
+        foolproof, and we cannot guarantee that your account and property
+        information will remain secure in the event of a breach.
+      </p>
+    </section>
+
+    <section id="booking-and-payment">
+      <b>7. Booking and Payment</b>
+      <p>
+        When Guests book a property, they are entering into a legal agreement
+        with the Host. Wanderlust acts solely as an intermediary and is not
+        responsible for the properties listed. Payment processing is handled by
+        third-party providers, and service fees may apply. Bookings are
+        confirmed upon receipt of payment.
+      </p>
+    </section>
+
+    <section id="property-cancellation-and-refunds">
+      <b>8. Property Cancellation and Refunds</b>
+      <p>
+        Guests may cancel their bookings at any time, with or without notice,
+        provided that the cancellation occurs within 24 hours of the booking. If
+        a Guest cancels their booking, they will be charged a cancellation fee
+        of 10% of the total booking price. Wanderlust will issue a full refund
+        to the Guest within 72 hours of the cancellation. If a Guest cancels
+        their booking after 24 hours, they will be charged a cancellation fee of
+        20% of the total booking price. Wanderlust will issue a partial refund
+        to the Guest within 48 hours of the cancellation.
+      </p>
+    </section>
+
+    <section id="host-responsibilities">
+      <b>9. Host Responsibilities</b>
+      <p>
+        As a Host, you are responsible for ensuring that your property is as
+        described in the listing, complies with local laws, and is safe for
+        Guests. You are also responsible for addressing any issues that arise
+        during a Guest's stay. All listings must be accurate, including pricing,
+        availability, and amenities.
+      </p>
+    </section>
+
+    <section id="guest-responsibilities">
+      <b>10. Guest Responsibilities</b>
+      <p>
+        As a Guest, you agree to follow the Host’s house rules, respect the
+        property, and comply with all applicable laws during your stay. You will
+        be held responsible for any damages to the property caused by you or
+        your invitees.
+      </p>
+    </section>
+
+    <section id="service-fees">
+      <b>11. Service Fees</b>
+      <p>
+        Wanderlust charges service fees to both Hosts and Guests for using the
+        platform. These fees are non-refundable and are displayed at the time of
+        booking or listing. Fees help maintain the platform and cover
+        operational costs.
+      </p>
+    </section>
+
+    <section id="taxes">
+      <b>12. Taxes</b>
+      <p>
+        Hosts are responsible for determining and fulfilling their tax
+        obligations related to the rental income generated from the platform.
+        Wanderlust may provide tax documentation as required but is not
+        responsible for withholding or remitting taxes on behalf of the Hosts.
+      </p>
+    </section>
+
+    <section id="prohibited-activities">
+      <b>13. Prohibited Activities</b>
+      <p>Users agree not to:</p>
+      <ul>
+        <li>Violate any applicable laws or regulations.</li>
+        <li>Post false, misleading, or fraudulent information.</li>
+        <li>
+          Interfere with the operation of the platform or engage in disruptive
+          activities.
+        </li>
+        <li>
+          Discriminate against other users based on race, religion, nationality,
+          disability, or any other protected category.
+        </li>
+      </ul>
+    </section>
+
+    <section id="dispute-resolution">
+      <b>14. Dispute Resolution</b>
+      <p>
+        In the event of a dispute between Guests and Hosts, Wanderlust may
+        facilitate communication but is not responsible for resolving conflicts.
+        We recommend that both parties attempt to resolve disputes amicably
+        before pursuing further action. In cases where mediation is required,
+        each party is responsible for its own legal costs.
+      </p>
+    </section>
+
+    <section id="indemnification">
+      <b>15. Indemnification</b>
+      <p>
+        You agree to indemnify and hold Wanderlust, its affiliates, and its
+        subsidiaries, officers, employees, agents, and contractors, harmless
+        from any and all claims, losses, damages, liabilities, and expenses,
+        including reasonable attorney's fees, arising out of or related to your
+        use of the Platform, your violation of these Terms, or your violation of
+        any third-party rights. You also agree to waive your right to sue in
+        your state or federal court.
+      </p>
+    </section>
+
+    <section id="limitation-of-liability">
+      <b>16. Limitation of Liability</b>
+      <p>
+        In no event shall Wanderlust, its affiliates, or its subsidiaries,
+        officers, employees, agents, or contractors be liable for any damages,
+        losses, or injuries, including, without limitation, any direct,
+        indirect, punitive, special, incidental, or consequential damages,
+        arising out of or related to the Platform, your use of the Platform,
+        your violation of these Terms, or your violation of any third-party
+        rights. This limitation of liability shall apply to the extent permitted
+        by law, and you acknowledge that you have the right to seek injunctive
+        relief in any court of competent jurisdiction.
+      </p>
+    </section>
+
+    <section id="governing-law-and-jurisdiction">
+      <b>17. Governing Law and Jurisdiction</b>
+      <p>
+        These Terms are governed by the laws of the State of California, without
+        regard to its conflict of law provisions. You agree that any disputes
+        arising out of or related to these Terms or your use of the Platform
+        will be resolved in Santa Clara County, California, by a court of
+        competent jurisdiction. If you reside outside of California, you consent
+        to the jurisdiction and venue of the California Supreme Court.
+      </p>
+    </section>
+
+    <section id="intellectual-property">
+      <b>18. Intellectual Property</b>
+      <p>
+        All content, including text, images, and software used on the platform,
+        is the intellectual property of Wanderlust or its licensors. You may not
+        copy, modify, or distribute any content from the platform without prior
+        written consent from Wanderlust.
+      </p>
+    </section>
+
+    <section id="privacy">
+      <b>19. Privacy</b>
+      <p>
+        Your use of the Wanderlust platform is also governed by our Privacy
+        Policy. We collect and process personal information in accordance with
+        our Privacy Policy, which can be found.
+      </p>
+    </section>
+
+    <section id="termination">
+      <b>20. Termination</b>
+      <p>
+        Wanderlust reserves the right to suspend or terminate your account at
+        any time if you violate these Terms or engage in prohibited activities.
+        Upon termination, you must cease all use of the platform and any
+        outstanding payments remain due.
+      </p>
+    </section>
+
+    <section id="amendments">
+      <b>21. Amendments</b>
+      <p>
+        We reserve the right to modify these Terms at any time. Any changes will
+        be effective immediately upon posting. You will be notified of
+        significant changes, and your continued use of the platform signifies
+        acceptance of the updated Terms.
+      </p>
+    </section>
+
+    <section id="contact-us">
+      <b>22. Contact Us</b>
+      <p>
+        If you have any questions about these Terms or require further
+        information, please contact us at:
+      </p>
+      <ul>
+        <li>Email: <b>support@wanderlust.com</b></li>
+        <li>Phone: <b>+123-456-7890</b></li>
+        <li>
+          Address: <b>123 Wanderlust Avenue, Dream City, Wonderland, 12345</b>
+        </li>
+      </ul>
+    </section>
+  </div>
 </body>


### PR DESCRIPTION
### Description
A clear and concise description of what the PR does.
- This PR does the following:
updates ui of privacy & terms&cond pages in footer by adding tables of content in each page and adding other visual changes.

### Related Issues
Link any related issues using the format `Fixes #issue_number`. 
This helps to automatically close related issues when the PR is merged.
- Placeholder: "Fixes #522"

### Changes
List the detailed changes made in this PR.
- added table of content in each page to scroll to sections given in specific page more easily and quickly
- improves navigation
- made sure it works in dark mode 
- is repsonsive
- other visual changes

### Testing Instructions
Detailed instructions on how to test the changes. Include any setup needed and specific test cases.
1. Pull this branch.
2. Run `npm install` to install dependencies.
3. Run `npm test` to execute the test suite.
4. Verify that ...

### Screenshots (if applicable)
changes made:

https://github.com/user-attachments/assets/727c8e5c-bd05-4671-9656-3a4f709d8842



### Additional Context
Any additional context or information that reviewers should be aware of.
- This PR is based on the following...

### Checklist
Make sure to check off all the items before submitting. Mark with [x] if done.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I am working on this issue under GSSOC
