### PR TITLE
Set the image upload limit of 4 for edit form

### DIFF
--- a/app.js
+++ b/app.js
@@ -231,7 +231,7 @@ app.get("/listing", asyncwrap(index));
 app.post("/listing", upload.array('listing[image]', 4), isLoggedIn, asyncwrap(createpost));
 app.post("/listing/search", asyncwrap(search));
 app.get("/listing/:id/edit", isLoggedIn, isOwner, asyncwrap(editpost));
-app.put('/listing/:id', isLoggedIn, isOwner, upload.array('listing[image]', 10), asyncwrap(saveEditpost));
+app.put('/listing/:id', isLoggedIn, isOwner, upload.array('listing[image]', 4), asyncwrap(saveEditpost));
 app.delete("/listing/:id", isLoggedIn, isOwner, asyncwrap(deletepost));
 app.get("/listing/:id", asyncwrap(showPost));
 app.post('/listing/:id/like', isLoggedIn, asyncwrap(listingController.likeListing));    

--- a/views/edit.ejs
+++ b/views/edit.ejs
@@ -124,8 +124,8 @@
 
                     <div class="mb-3 edit_form">
                         <label for="images" class="form-label">Upload New Images</label>
-                        <input type="file" name="listing[image]" class="form-control" accept="image/*" multiple>
-                        <small class="form-text text-muted">You can upload multiple images.</small>
+                        <input type="file" name="listing[image]" class="form-control" accept="image/*" id="fileInput" multiple>
+                        <small class="form-text text-muted">You can upload multiple <images id="fileError" class="">(Maximum 4)</images></small>
                     </div>
                     <div class="row">
 


### PR DESCRIPTION
### Description
Set the image upload limit of 4 for edit form. Both frontend and backend.

### Related Issues
Link any related issues using the format `Fixes #issue_number`. 
This helps to automatically close related issues when the PR is merged.
- Placeholder: "Fixes #392 "

### Screenshots (if applicable)
Add any screenshots that help explain or visualize the changes.

https://github.com/user-attachments/assets/69656332-ac31-45d9-86c5-5df9d596d92c


### Checklist
Make sure to check off all the items before submitting. Mark with [x] if done.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I am working on this issue under GSSOC

### @Soujanya2004   Marge it. And don't forget to add all the labels as per ISSUE #392 